### PR TITLE
Assert specific system exit statuses

### DIFF
--- a/src/final1/subtests/RecommendationSubtest.java
+++ b/src/final1/subtests/RecommendationSubtest.java
@@ -1,6 +1,7 @@
 package final1.subtests;
 
-import static org.hamcrest.CoreMatchers.is;
+import static test.KitMatchers.suits;
+
 import static org.junit.Assert.assertThat;
 import test.Input;
 import test.InteractiveConsoleTest;
@@ -136,7 +137,7 @@ public abstract class RecommendationSubtest extends InteractiveConsoleTest {
 		TestObject.allowSystemExit(SystemExitStatus.ALL);
 		errorTest(commands, args0);
 		assertThat(consoleMessage(commands, args0) + "\nWrong system exit status!",
-			TestObject.getLastMethodsSystemExitStatus(), is(SystemExitStatus.WITH_GREATER_THAN_0));
+			TestObject.getLastMethodsSystemExitStatus(), suits(SystemExitStatus.WITH_GREATER_THAN_0, true));
 	}
 
 	/*

--- a/src/test/InteractiveConsoleTest.java
+++ b/src/test/InteractiveConsoleTest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import static test.KitMatchers.suits;
+
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -140,7 +142,7 @@ public abstract class InteractiveConsoleTest {
 
 	/**
 	 * Checks the exit status of a tested method. Has to be called after call to a {@link TestObject} run method.
-	 *
+	 * 
 	 * @param commands
 	 *            The commands that were run on the interactive console.
 	 * @param args0
@@ -152,14 +154,14 @@ public abstract class InteractiveConsoleTest {
 		if (!newSystemExitStatusCeckInited) {
 			throw new IllegalStateException("The new way of system exit status checking has not been inited yet!");
 		}
-		if ((allowedExitStatus != null) || (expectedExitStatus != null)) {
-			SystemExitStatus actualStatus = TestObject.getLastMethodsSystemExitStatus();
+		if (allowedExitStatus != null || expectedExitStatus != null) {
+			Integer actualStatus = TestObject.getLastMethodsSystemExitStatus();
 			if (expectedExitStatus != null) {
 				assertThat(consoleMessage(commands, args0) + "\nWrong system exit status!", actualStatus,
-					is(expectedExitStatus));
-			} else if ((actualStatus != SystemExitStatus.NONE) && (allowedExitStatus != SystemExitStatus.ALL)) {
+					suits(expectedExitStatus, true));
+			} else {
 				assertThat(consoleMessage(commands, args0) + "\nWrong system exit status!", actualStatus,
-					is(allowedExitStatus));
+					suits(allowedExitStatus, false));
 			}
 			TestObject.allowSystemExit(oldDefault);
 		}
@@ -373,7 +375,7 @@ public abstract class InteractiveConsoleTest {
 	 * Example:<br>
 	 * Say we expect the main method to output three times {@code "Success!"}, an empty line afterwards, and then a line
 	 * starting with {@code "Error,"}. The call would work like this: <br>
-	 *
+	 * 
 	 * <pre>
 	 * <code>
 	 * {@code
@@ -386,7 +388,7 @@ public abstract class InteractiveConsoleTest {
 	 * }
 	 * </code>
 	 * </pre>
-	 *
+	 * 
 	 * @param commands
 	 *            The commands to run on the console.
 	 * @param expectedResults

--- a/src/test/KitMatchers.java
+++ b/src/test/KitMatchers.java
@@ -81,6 +81,36 @@ public class KitMatchers {
 	}
 
 	/**
+	 * Creates a matcher that matches if the examined Integer suits the needs implied by {@code systemExitStatus}.
+	 * 
+	 * @param systemExitStatus
+	 *            The exit status any examined Integer is expected to match
+	 * @param mandatory
+	 *            Whether it was mandatory for the tested class to call {@code System.exit} the way defined by
+	 *            {@code SystemExitStatus}.
+	 */
+	public static Matcher<Integer> suits(final SystemExitStatus systemExitStatus, final boolean mandatory) {
+		return new BaseMatcher<Integer>() {
+
+			@Override
+			public boolean matches(final Object testObject) {
+				Integer status = (Integer) testObject;
+				return systemExitStatus.matches(status, mandatory);
+			}
+
+			@Override
+			public void describeTo(Description description) {
+				description.appendText(systemExitStatus.toString());
+			}
+
+			@Override
+			public void describeMismatch(final Object item, final Description description) {
+				description.appendText("was System.exit(" + item + ")");
+			}
+		};
+	}
+
+	/**
 	 * Creates a matcher that matches if the examined String array contains exactly as much elements as specified by
 	 * {@code outputLines}. This matcher is meant to assert a tested class' output. It provides a appropriate error
 	 * message.

--- a/src/test/SystemExitStatus.java
+++ b/src/test/SystemExitStatus.java
@@ -4,7 +4,7 @@ package test;
  * Represents a status {@link System#exit} can be called with.
  *
  * @author Joshua Gleitze
- * @version 1.0
+ * @version 1.2
  */
 public enum SystemExitStatus {
 	/**
@@ -22,7 +22,13 @@ public enum SystemExitStatus {
 	/**
 	 * {@code System.exit(x)} with x>0.
 	 */
-	WITH_GREATER_THAN_0;
+	WITH_GREATER_THAN_0,
+	/**
+	 * {@code System.exit(x)} with a x that has to be specified through {@link #setExactStatus()}.
+	 */
+	EXACTLY;
+
+	private int exactSystemExitStatus = -1;
 
 	@Override
 	public String toString() {
@@ -35,8 +41,74 @@ public enum SystemExitStatus {
 			return "System.exit(0)";
 		case WITH_GREATER_THAN_0:
 			return "System.exit(x) with any x > 0";
+		case EXACTLY:
+			return "System.exit(" + exactSystemExitStatus + ")";
 		default:
 			throw new IllegalArgumentException();
 		}
+	}
+
+	/**
+	 * @param status
+	 *            A status {@code System.exit} was called with.
+	 * @param mandatory
+	 *            Whether it was obligatory to call {@code System.exit}.
+	 * @return Whether {@code status} matches the system exit status described by this enum instance. If {@code status}
+	 *         is null, and {@code obligatory} is {@code true}, this method always returns {@code false}. If
+	 *         {@code status} is null, and {@code obligatory} is {@code false}, this method always returns {@code true}.
+	 */
+	public boolean matches(Integer status, boolean mandatory) {
+		if (status == null) {
+			return !mandatory;
+		}
+		switch (this) {
+		case ALL:
+			return true;
+		case NONE:
+			return false;
+		case WITH_0:
+			return status == 0;
+		case WITH_GREATER_THAN_0:
+			return status > 0;
+		case EXACTLY:
+			return status == exactSystemExitStatus;
+		default:
+			throw new IllegalStateException("this was not recognised!");
+		}
+	}
+
+	/**
+	 * @return If this is {@link #EXACTLY}, the exact status implied by the enum.
+	 * @throws IllegalStateException
+	 *             If {@code this} is not {@link #EXACTLY} or {@link #setExactStatus(int)} has not been called yet.
+	 */
+	public int getExactStatus() {
+		if (this != EXACTLY) {
+			throw new IllegalStateException("This method may only be called for the EXACTLY enum");
+		}
+		if (exactSystemExitStatus == -1) {
+			throw new IllegalStateException("The exact status has not been set yet!");
+		}
+		return exactSystemExitStatus;
+	}
+
+	/**
+	 * @param status
+	 *            The status that is implied by {@link #EXACTLY}.
+	 * @return {@code this}
+	 * @throws IllegalStateException
+	 *             If {@code this} is not {@link #EXACTLY}.
+	 * @throws IllegalArgumentException
+	 *             If {@code status < 0}.
+	 */
+	public SystemExitStatus status(int status) {
+		if (this != EXACTLY) {
+			throw new IllegalStateException("This method may only be called for the EXACTLY enum");
+		}
+		if (status < 0) {
+			throw new IllegalArgumentException("There is no system exit status lower than 0!");
+		}
+		this.exactSystemExitStatus = status;
+		return this;
 	}
 }

--- a/src/test/TestObject.java
+++ b/src/test/TestObject.java
@@ -94,7 +94,7 @@ import test.framework.TestClassLoader;
  * exception thrown in the tested class is an instance of the specified classes, it is wrapped in a
  * {@link TestMethodException} which is then thrown. For example, if we would like to test that a method throws a
  * {@code FooException}, we would do the following:
- *
+ * 
  * <pre>
  * <code>
  * TestObject.rethrowException(FooException);
@@ -108,21 +108,21 @@ import test.framework.TestClassLoader;
  * }
  * </code>
  * </pre>
- *
+ * 
  * <h5>static fields</h5>
  * If you test methods, it might happen that the implementation you test uses static fields. Especially when you test a
  * {@code main} method, you usually want to the test the class in the state it is when the program is started.
  * Otherwise, consecutive calls of {@code main} may result in different results! So whenever you test a {@code main}
  * method or something that shall only be called once per program run, make sure to use {@link #resetClass()}:
- *
+ * 
  * <pre>
  * <code>
  * TestObject.resetClass(); // Always reset the class before running main!
  * TestObject.runStaticVoid("main");
  * </pre>
- *
+ * 
  * </code>
- *
+ * 
  * @author Joshua Gleitze
  * @version 2.2
  */
@@ -131,9 +131,9 @@ public class TestObject {
 	private static final String CLASS_NAME = System.getProperty("className");
 
 	private static Class<?> clazz;
-
+	
 	private static String[][] groupedProgramOutput = new String[0][];
-	private static SystemExitStatus lastSystemExitStatus = SystemExitStatus.NONE;
+	private static Integer lastSystemExitStatus = null;
 	private static String[] nextCallInput;
 	private static String[] programOutput = new String[0];
 	private static List<Class<? extends Exception>> rethrowExceptions = new LinkedList<Class<? extends Exception>>();
@@ -146,7 +146,7 @@ public class TestObject {
 	/**
 	 * Constructs an {@code TestObject} that represents an instance of the tested class. The constructor of the tested
 	 * class whose formal arguments match {@code argumentTypes} will be selected to construct this instance.
-	 *
+	 * 
 	 * @param formalArguments
 	 *            The classes of the test class' constructor's formal arguments. The constructor will be selected based
 	 *            on the classes you provide.
@@ -154,13 +154,13 @@ public class TestObject {
 	 *            The arguments to be passed to the constructor.
 	 */
 	public TestObject(Class<?>[] formalArguments, Object... arguments) {
-		instance = run(clazz, "", formalArguments, arguments, null, true);
+		this.instance = run(clazz, "", formalArguments, arguments, null, true);
 	}
 
 	/**
 	 * Constructs an {@code TestObject} that represents an instance of the tested class. The constructor of the tested
 	 * class whose formal arguments match the classes of {@code arguments} will be selected to construct this instance.
-	 *
+	 * 
 	 * @param arguments
 	 *            The arguments to be passed to the constructor of the tested class in the correct order. The
 	 *            constructor will be selected based on their types.
@@ -171,14 +171,14 @@ public class TestObject {
 
 	/**
 	 * Constructs a {@code TestObject} to represent {@code injectedInstance}.
-	 *
+	 * 
 	 * @param injectInstance
 	 *            set this to whatever you want. Only used to distinguish from other constructors.
 	 * @param injectedInstance
 	 *            The instance the constructed {@code TestObject} will represent.
 	 */
 	private TestObject(boolean injectInstance, Object injectedInstance) {
-		instance = injectedInstance;
+		this.instance = injectedInstance;
 	}
 
 	/**
@@ -187,7 +187,7 @@ public class TestObject {
 	 * to call {@link System#exit} in any way (this status can be achieved by calling
 	 * {@code allowSystemExit(SystemExitStatus.NONE)} . {@link org.junit.Assert#fail} will be called if the tested class
 	 * tries to call {@code System.exit} with a status it is not allowed to.
-	 *
+	 * 
 	 * @param status
 	 *            The status you want to allow calling {@link System#exit} with.
 	 */
@@ -207,7 +207,7 @@ public class TestObject {
 
 	/**
 	 * Gets everything the tested class printed through {@code Terminal.printLine} during the last method run.
-	 *
+	 * 
 	 * @return What the last method run printed through {@code Terminal.printLine} concatenated with
 	 *         {@code System.lineSeperator()}.
 	 */
@@ -241,7 +241,7 @@ public class TestObject {
 	/**
 	 * Gets everything the tested class printed through {@code Terminal.printLine} during the last method run. One
 	 * element of the array represents one call to {@code Terminal.printLine}.
-	 *
+	 * 
 	 * @return What the last method run printed through {@code Terminal.printLine}.
 	 */
 	public static String[] getLastMethodsOutput() {
@@ -249,17 +249,16 @@ public class TestObject {
 	}
 
 	/**
-	 * @return {@link SystemExitStatus#NONE} if the last method run didn't call {@code System.exit(x)}.
-	 *         {@link SystemExitStatus#WITH_0} or {@link SystemExitStatus#WITH_GREATER_THAN_0} if the last method run
-	 *         called {@code System.exit(x)} with {@code x=0} or {@code x>0}, respectively.
+	 * @return The status the last method run called {@code System.exit} with. {@code null} if the last method run did
+	 *         not call {@code System.exit}.
 	 */
-	public static SystemExitStatus getLastMethodsSystemExitStatus() {
+	public static Integer getLastMethodsSystemExitStatus() {
 		return lastSystemExitStatus;
 	}
 
 	/**
 	 * Gets the package the tested class is in.
-	 *
+	 * 
 	 * @return The name of the package the tested class is in. If the tested class has no package (= is in the default
 	 *         package {@code null} is returned.
 	 */
@@ -272,7 +271,7 @@ public class TestObject {
 
 	/**
 	 * Returns the simple name of the tested class.
-	 *
+	 * 
 	 * @return What {@code object.class.getSimpleName()} returns if {@code object} is an instance of the tested class.
 	 */
 	public static String getSimpleName() {
@@ -282,7 +281,7 @@ public class TestObject {
 	/**
 	 * Returns whether the tested class implements a method called {@code methodName} that takes multiple arguments of
 	 * the types specified in {@code argumentTypes}.
-	 *
+	 * 
 	 * @param methodName
 	 *            The name of the method you want to check for.
 	 * @param formalArguments
@@ -301,7 +300,7 @@ public class TestObject {
 
 	/**
 	 * Returns a String that represents a call of a method.
-	 *
+	 * 
 	 * @param methodName
 	 *            The method's name
 	 * @param parameters
@@ -325,7 +324,7 @@ public class TestObject {
 			} else {
 				result += parameters[i].toString();
 			}
-			result += (i < (parameters.length - 1)) ? ", " : "";
+			result += (i < parameters.length - 1) ? ", " : "";
 		}
 		result += ")";
 		return result;
@@ -333,7 +332,7 @@ public class TestObject {
 
 	/**
 	 * Returns a String that represents the formal declaration of a method.
-	 *
+	 * 
 	 * @param methodName
 	 *            The method's name
 	 * @param formalArguments
@@ -360,7 +359,7 @@ public class TestObject {
 		} else {
 			for (int i = 0; i < formalArguments.length; i++) {
 				result += formalArguments[i].getSimpleName();
-				result += (i < (formalArguments.length - 1)) ? ", " : "";
+				result += (i < formalArguments.length - 1) ? ", " : "";
 			}
 		}
 		result += ")";
@@ -378,7 +377,7 @@ public class TestObject {
 				+ "Example: '-DclassName=joshuagleitze.tuple.NaturalNumberTuple'\n\n"
 				+ "For help to set up the tests, see\n"
 				+ "https://github.com/jGleitz/JUnit-KIT/wiki/Using-the-tests-in-Eclipse\n";
-		if ((CLASS_NAME == null) || CLASS_NAME.equals("")) {
+		if (CLASS_NAME == null || CLASS_NAME.equals("")) {
 			fail("\nYou have not provided a class name! So what should we test on?" + standardMessage);
 		}
 		try {
@@ -397,7 +396,7 @@ public class TestObject {
 	 * {@code rethrowExceptions} is called again. To rethrow all exceptions, call
 	 * {@code rethrowExceptions(Exception.class)}. To always output an error message (which is the default), run
 	 * {@code rethrowExceptions()} or {@code rethrowExceptions(null)}.
-	 *
+	 * 
 	 * @param exceptionClasses
 	 *            If an exception occurs that is an instance of an exception class in {@code exceptionClasses}, it will
 	 *            be rethrown.
@@ -418,7 +417,7 @@ public class TestObject {
 	/**
 	 * Runs a static method on the tested class. The method named {@code methodName} taking the formal arguments
 	 * {@code formalArguments} will be selected.
-	 *
+	 * 
 	 * @param <T>
 	 *            The return type. (Set trough {@code expectedReturnType}).
 	 * @param expectedReturnType
@@ -439,7 +438,7 @@ public class TestObject {
 	/**
 	 * Runs a static method on the tested class. The method named {@code methodName} taking the classes of
 	 * {@code arguments} as formal arguments will be selected.
-	 *
+	 * 
 	 * @param <T>
 	 *            The return type. (Set trough {@code expectedReturnType}).
 	 * @param expectedReturnType
@@ -457,7 +456,7 @@ public class TestObject {
 	/**
 	 * Runs a static void method on the tested class. The method named {@code methodName} taking the formal arguments
 	 * {@code formalArguments} will be selected.
-	 *
+	 * 
 	 * @param methodName
 	 *            The name of the static void method you want to call.
 	 * @param formalArguments
@@ -472,7 +471,7 @@ public class TestObject {
 	/**
 	 * Runs a static void method on the tested class. The method named {@code methodName} taking the classes of
 	 * {@code arguments} as formal arguments will be selected.
-	 *
+	 * 
 	 * @param methodName
 	 *            The name of the static void method you want to call.
 	 * @param arguments
@@ -487,7 +486,7 @@ public class TestObject {
 	 * per call to {@code Terminal.readLine()}. Calls {@code setNextMethodCallInput(input.split(System.lineSeparator())} <br>
 	 * <br>
 	 * The test framework does not expect the Terminal class to be present at the user's build path.
-	 *
+	 * 
 	 * @param input
 	 *            the input that should be provided through the {@code Terminal} class on the next method call.
 	 */
@@ -501,7 +500,7 @@ public class TestObject {
 	 * {@code setNextMethodCallInput(input.split(System.lineSeparator())} <br>
 	 * <br>
 	 * The test framework does not expect the Terminal class to be present at the user's build path.
-	 *
+	 * 
 	 * @param input
 	 *            the input that should be provided through the {@code Terminal} class on the next method call.
 	 */
@@ -511,7 +510,7 @@ public class TestObject {
 
 	/**
 	 * Calls {@link #translateToTestObject(Object)} on an Array of objects.
-	 *
+	 * 
 	 * @param objects
 	 *            the objects to convert
 	 * @return A copy of {@code objects} where any occurrence of an instance of the tested class has been converted to
@@ -530,7 +529,7 @@ public class TestObject {
 
 	/**
 	 * Converts an instance of the tested class into an instance of {@code TestObject} that represents it.
-	 *
+	 * 
 	 * @param object
 	 *            an object to convert
 	 * @return If {@code object}'s class is the tested class, an instance of {@code TestObject} that represents is.
@@ -554,7 +553,7 @@ public class TestObject {
 	 * class of the primitive type will be used, not the primitive wrapper class. (E.g. for both {@code 3} and
 	 * {@code new Integer(3)}, {@code int.class} will be used instead of {@code Integer.class}). For instances of
 	 * {@code TestObject}, the tested class will be used.
-	 *
+	 * 
 	 * @param arguments
 	 *            The Objects you want to get the classes of.
 	 * @return The classes of {@code arguments}
@@ -588,7 +587,7 @@ public class TestObject {
 
 	/**
 	 * Check if a class is a primitve type wrapper of a primitive type.
-	 *
+	 * 
 	 * @param wrapper
 	 *            the wrapper class to check
 	 * @param primitiveClass
@@ -618,7 +617,7 @@ public class TestObject {
 
 	/**
 	 * Runs a method on the instance.
-	 *
+	 * 
 	 * @param expectedReturnType
 	 *            The class of the return type you expect. {@link Assert#fail()} will be called if the method returns
 	 *            something that is not an instance of {@code expectedReturnType}
@@ -673,7 +672,7 @@ public class TestObject {
 			for (int i = 0; i < arguments.length; i++) {
 				message += "(" + passedTypes[i].getName() + ") ";
 				message += arguments[i];
-				message += (i < (arguments.length - 1)) ? ", " : "";
+				message += (i < arguments.length - 1) ? ", " : "";
 			}
 			message += "' don't match the formal arguments of the "
 					+ renderMethodFormal(methodName, formalArguments, (inst == null), callConstructor)
@@ -682,32 +681,11 @@ public class TestObject {
 			fail(message);
 		} catch (InvocationTargetException e) {
 			StringWriter stackTraceStringWriter = new StringWriter(); // will hold the printed stack trace of the actual
-			// error.
+																		// error.
 			if (e.getCause() instanceof ExitException) {
 				ExitException exitException = (ExitException) e.getCause();
 				exitException.printStackTrace(new PrintWriter(stackTraceStringWriter));
-				boolean failBecauseOfWrongStatus = false;
-				switch (allowedSystemExitStatus) {
-				case ALL:
-					failBecauseOfWrongStatus = false;
-					break;
-				case NONE:
-					failBecauseOfWrongStatus = true;
-					break;
-				case WITH_0:
-					if (exitException.getStatus() != 0) {
-						failBecauseOfWrongStatus = true;
-					}
-					break;
-				case WITH_GREATER_THAN_0:
-					if (!(exitException.getStatus() > 0)) {
-						failBecauseOfWrongStatus = true;
-					}
-					break;
-				default:
-					throw new IllegalArgumentException("The allowed system exit status may not be null!");
-				}
-				if (failBecauseOfWrongStatus) {
+				if (!allowedSystemExitStatus.matches(exitException.getStatus(), false)) {
 					String message = "While calling " + renderMethodCall(methodName, arguments, callConstructor)
 							+ ", your code called System.exit(" + exitException.getStatus()
 							+ "). This was not expected and is an error: \n\n" + stackTraceStringWriter.toString();
@@ -743,7 +721,7 @@ public class TestObject {
 			}
 			return null;
 		}
-		if ((result != null) && !expectedReturnType.isInstance(result) && !isWrapperOf(result, expectedReturnType)) {
+		if (result != null && !expectedReturnType.isInstance(result) && !isWrapperOf(result, expectedReturnType)) {
 			fail("The " + renderMethodFormal(methodName, formalArguments, (inst == null), callConstructor)
 					+ " is expected to return a " + expectedReturnType.getSimpleName() + " but instead returned a "
 					+ result.getClass().getSimpleName() + ".\n");
@@ -753,7 +731,7 @@ public class TestObject {
 
 	/**
 	 * Calls {@link #translateClassToImplemented(Class)} on an Array of classes.
-	 *
+	 * 
 	 * @param classes
 	 *            the classes to convert
 	 * @return A copy of {@code classes} where all occurrences of {@code TestObject.class} have been converted into the
@@ -772,7 +750,7 @@ public class TestObject {
 
 	/**
 	 * Calls {@link #translateToImplemented(Object)} on an Array of objects.
-	 *
+	 * 
 	 * @param objects
 	 *            the objects to convert
 	 * @return A copy of {@code objects} where any occurrence of an instance of {@code TestObject} has been converted
@@ -791,7 +769,7 @@ public class TestObject {
 
 	/**
 	 * Converts {@code TestObject.class} into the tested class.
-	 *
+	 * 
 	 * @param c
 	 *            a class to convert
 	 * @return If {@code c} is {@code TestObject.class}, the tested class will be returned. Otherwise, {@code clazz} is
@@ -807,7 +785,7 @@ public class TestObject {
 
 	/**
 	 * Converts an instance of {@code TestObject} to the instance of the tested class represented by it.
-	 *
+	 * 
 	 * @param object
 	 *            An object to convert.
 	 * @return If {@code object}'s class is {@code TestObject.class}, the instance of the tested class {@code object}
@@ -828,7 +806,7 @@ public class TestObject {
 
 	/**
 	 * Compares if the instances of the tested class represented by {@code this} and {@code otherTestObject} are equal.
-	 *
+	 * 
 	 * @param otherTestObject
 	 *            an instance of {@code TestObject} you want to check.
 	 * @return if the instance of the tested class represented by {@code this} and the instance of the tested class
@@ -839,23 +817,23 @@ public class TestObject {
 		if (!(otherTestObject instanceof TestObject)) {
 			return false;
 		}
-		return (instance.equals(((TestObject) otherTestObject).instance));
+		return (this.instance.equals(((TestObject) otherTestObject).instance));
 	}
 
 	/**
 	 * Returns the hashCode of the instance of the tested class represented by {@code this}.
-	 *
+	 * 
 	 * @return What {@code hashCode} of the instance of the tested class represented by {@code this} returns.
 	 */
 	@Override
 	public int hashCode() {
-		return instance.hashCode();
+		return this.instance.hashCode();
 	}
 
 	/**
 	 * Runs a method on the instance of tested class represented by {@code this}. The method named {@code methodName}
 	 * taking the formal arguments {@code formalArguments} will be selected.
-	 *
+	 * 
 	 * @param <T>
 	 *            The return type. (Set trough {@code expectedReturnType}).
 	 * @param expectedReturnType
@@ -869,13 +847,13 @@ public class TestObject {
 	 * @return What the method returns.
 	 */
 	public <T> T run(Class<T> expectedReturnType, String methodName, Class<?>[] formalArguments, Object... arguments) {
-		return run(expectedReturnType, methodName, formalArguments, arguments, instance, false);
+		return run(expectedReturnType, methodName, formalArguments, arguments, this.instance, false);
 	}
 
 	/**
 	 * Runs a method on the instance of tested class represented by {@code this}. The method named {@code methodName}
 	 * taking the classes of {@code arguments} as formal arguments will be selected.
-	 *
+	 * 
 	 * @param <T>
 	 *            The return type. (Set trough {@code expectedReturnType}).
 	 * @param expectedReturnType
@@ -893,7 +871,7 @@ public class TestObject {
 	/**
 	 * Runs a void method on the instance of tested class represented by {@code this}. The method named
 	 * {@code methodName} taking the formal arguments {@code formalArguments} will be selected.
-	 *
+	 * 
 	 * @param methodName
 	 *            The name of the static void method you want to call.
 	 * @param formalArguments
@@ -902,13 +880,13 @@ public class TestObject {
 	 *            The arguments you want to pass to the method.
 	 */
 	public void runVoid(String methodName, Class<?>[] formalArguments, Object... arguments) {
-		run(null, methodName, formalArguments, arguments, instance, false);
+		run(null, methodName, formalArguments, arguments, this.instance, false);
 	}
 
 	/**
 	 * Runs a void method on the instance of tested class represented by {@code this}. The method named
 	 * {@code methodName} taking the classes of {@code arguments} as formal arguments will be selected.
-	 *
+	 * 
 	 * @param methodName
 	 *            The name of the static void method you want to call.
 	 * @param arguments

--- a/src/test/framework/NoExitSecurityManager.java
+++ b/src/test/framework/NoExitSecurityManager.java
@@ -2,8 +2,6 @@ package test.framework;
 
 import java.security.Permission;
 
-import test.SystemExitStatus;
-
 /**
  * Used to catch when the code is trying to call {@link System#exit}. This would leave a test in a hanging state. A
  * {@link ExitException} is thrown if the code tries to call {@link System#exit}.
@@ -13,7 +11,7 @@ import test.SystemExitStatus;
  */
 public class NoExitSecurityManager extends SecurityManager {
 	private Class<?> targetClass;
-	private SystemExitStatus lastExit = SystemExitStatus.NONE;
+	private Integer lastExit = null;
 
 	/**
 	 * Constructs a {@code NoExitSecurityManager}
@@ -28,12 +26,8 @@ public class NoExitSecurityManager extends SecurityManager {
 	@Override
 	public void checkExit(int status) {
 		super.checkExit(status);
-		if (status > 0) {
-			lastExit = SystemExitStatus.WITH_GREATER_THAN_0;
-		} else if (status == 0) {
-			lastExit = SystemExitStatus.WITH_0;
-		}
-		Class<?>[] classContext = getClassContext();
+		this.lastExit = status;
+		Class<?>[] classContext = this.getClassContext();
 		for (Class<?> c : classContext) {
 			if (c == targetClass) {
 				throw new ExitException(status);
@@ -52,20 +46,17 @@ public class NoExitSecurityManager extends SecurityManager {
 	}
 
 	/**
-	 * Sets the last exit status to {@link SystemExitStatus#NONE}.
+	 * Sets the last exit status to {@code null}.
 	 */
 	public void resetLastExitStatus() {
-		lastExit = SystemExitStatus.NONE;
+		lastExit = null;
 	}
 
 	/**
-	 * @return {@link SystemExitStatus#NONE} if no class using this security manager called {@code System.exit(x)} since
-	 *         its creation or the last call to {@link NoExitSecurityManager#resetLastExitStatus()}.
-	 *         {@link SystemExitStatus#WITH_0} or {@link SystemExitStatus#WITH_GREATER_THAN_0} if the last call to
-	 *         {@code System.exit(x)} of a class using this security manager was with {@code x=0} or {@code x>0},
-	 *         respectively.
+	 * @return The last status a class using this security manager called {@code System.exit} with. {@code null} if no
+	 *         call to {@code System.exit} was recognised since the last call to {@link #resetLastExitStatus()}.
 	 */
-	public SystemExitStatus lastExitStatus() {
-		return lastExit;
+	public Integer lastExitStatus() {
+		return this.lastExit;
 	}
 }


### PR DESCRIPTION
Fixing #54: This pull introduces `SystemExitStatus#EXACTLY` which allows to specify an exact exit status other than `0`.
