### PR TITLE
final1: Add complex graph with recommend test

### DIFF
--- a/src/final1/RecommendationTest.java
+++ b/src/final1/RecommendationTest.java
@@ -10,6 +10,7 @@ import final1.subtests.InvalidInputFileTest;
 import final1.subtests.InvalidRecommendTerms;
 import final1.subtests.ValidInputFileTest;
 import final1.subtests.ValidNodesCommandTest;
+import final1.subtests.ValidRecommendCommandTest;
 
 /**
  * Test suite for the programming lecture's first final test.
@@ -24,6 +25,7 @@ import final1.subtests.ValidNodesCommandTest;
 		ValidInputFileTest.class,
 		InvalidInputFileTest.class,
 		ValidNodesCommandTest.class,
+		ValidRecommendCommandTest.class,
 		InvalidRecommendTerms.class
 })
 public class RecommendationTest {

--- a/src/final1/RecommendationTest.java
+++ b/src/final1/RecommendationTest.java
@@ -5,6 +5,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import final1.subtests.BasicCommandTest;
+import final1.subtests.EdgesCommandTest;
 import final1.subtests.InvalidCommandLineArgumentsTest;
 import final1.subtests.InvalidInputFileTest;
 import final1.subtests.InvalidRecommendTerms;
@@ -26,7 +27,8 @@ import final1.subtests.ValidRecommendCommandTest;
 		InvalidInputFileTest.class,
 		ValidNodesCommandTest.class,
 		ValidRecommendCommandTest.class,
-		InvalidRecommendTerms.class
+		InvalidRecommendTerms.class,
+		EdgesCommandTest.class
 })
 public class RecommendationTest {
 }

--- a/src/final1/RecommendationTest.java
+++ b/src/final1/RecommendationTest.java
@@ -6,6 +6,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import final1.subtests.BasicCommandTest;
 import final1.subtests.EdgesCommandTest;
+import final1.subtests.ExportCommandTest;
 import final1.subtests.InvalidCommandLineArgumentsTest;
 import final1.subtests.InvalidInputFileTest;
 import final1.subtests.InvalidRecommendTerms;
@@ -28,7 +29,8 @@ import final1.subtests.ValidRecommendCommandTest;
 		ValidNodesCommandTest.class,
 		ValidRecommendCommandTest.class,
 		InvalidRecommendTerms.class,
-		EdgesCommandTest.class
+		EdgesCommandTest.class,
+		ExportCommandTest.class
 })
 public class RecommendationTest {
 }

--- a/src/final1/subtests/BasicCommandTest.java
+++ b/src/final1/subtests/BasicCommandTest.java
@@ -31,7 +31,9 @@ public class BasicCommandTest extends RecommendationSubtest {
 			" recommend S1 105",
 			"quit ",
 			"quit test",
-			" quit"
+			" quit",
+			"",
+			" "
 	};
 
 	public BasicCommandTest() {

--- a/src/final1/subtests/EdgesCommandTest.java
+++ b/src/final1/subtests/EdgesCommandTest.java
@@ -1,0 +1,122 @@
+package final1.subtests;
+
+import java.util.List;
+
+import org.hamcrest.Matcher;
+import org.junit.Test;
+
+import test.Input;
+import test.KitMatchers;
+import test.SystemExitStatus;
+import test.runs.LineRun;
+import test.runs.NoOutputRun;
+import test.runs.Run;
+
+/**
+ * Performs calls to the {@code edges} command and checks the results.
+ */
+public class EdgesCommandTest extends RecommendationSubtest {
+
+	public EdgesCommandTest() {
+		setAllowedSystemExitStatus(SystemExitStatus.WITH_0);
+	}
+
+	/**
+	 * Asserts correct results for the example given on the task sheet.
+	 */
+	@Test
+	public void taskSheetExampleTest() {
+		testAgainstTaskSheet(TASK_SHEET_INPUT_FILE);
+		testAgainstTaskSheet(TASK_SHEET_INPUT_FILE_SPACES); // why not...
+	}
+
+	/**
+	 * Asserts correct results if the input file contains semantical duplicates.
+	 */
+	@Test
+	public void duplicatesTest() {
+		testEdges(new String[] {
+				"A contains B",
+				"A contains B"
+		}, new String[] {
+				"a-[contains]->b",
+				"b-[contained-in]->a"
+		});
+
+		testAgainstTaskSheet(TASK_SHEET_INPUT_FILE_DUPLICATES);
+	}
+
+	/**
+	 * Asserts correct results for simple one line input files.
+	 */
+	@Test
+	public void oneLineTest() {
+		testEdges(ONE_LINE_INPUT_FILE1, new String[] {
+				"b:1-[successor-of]->a:2",
+				"a:2-[predecessor-of]->b:1"
+		});
+
+		testEdges(ONE_LINE_INPUT_FILE2, new String[] {
+				"a-[contains]->b:2",
+				"b:2-[contained-in]->a"
+		});
+	}
+
+	/**
+	 * Asserts that product ID 0 can be handled correctly.
+	 */
+	@Test
+	public void zeroIdTest() {
+		testEdges(ZERO_ID_INPUT_FILE, new String[] {
+				"a-[contains]->b:0",
+				"b:0-[contained-in]->a",
+				"a-[contains]->c:1",
+				"c:1-[contained-in]->a"
+		});
+	}
+
+	private void testAgainstTaskSheet(String[] input) {
+		// the following queries/matchers are NOT taken from the task sheet (only the first 11 are)
+		String[] nodes = new String[] {
+				"calc:202-[contained-in]->officesuite",
+				"calc:202-[part-of]->libreoffice:200",
+				"centos5:105-[contained-in]->operatingsystem",
+				"centos5:105-[predecessor-of]->centos6:106",
+				"centos6:106-[contained-in]->operatingsystem",
+				"centos6:106-[predecessor-of]->centos7:107",
+				"centos6:106-[successor-of]->centos5:105",
+				"centos7:107-[contained-in]->operatingsystem",
+				"centos7:107-[successor-of]->centos6:106",
+				"impress:203-[contained-in]->officesuite",
+				"impress:203-[part-of]->libreoffice:200",
+				"writer:201-[part-of]->libreoffice:200",
+				"writer:201-[contained-in]->officesuite",
+				"libreoffice:200-[contained-in]->officesuite",
+				"libreoffice:200-[has-part]->writer:201",
+				"libreoffice:200-[has-part]->calc:202",
+				"libreoffice:200-[has-part]->impress:203",
+				"officesuite-[contained-in]->software",
+				"officesuite-[contains]->writer:201",
+				"officesuite-[contains]->libreoffice:200",
+				"officesuite-[contains]->impress:203",
+				"officesuite-[contains]->calc:202",
+				"software-[contains]->officesuite",
+				"software-[contains]->operatingsystem",
+				"operatingsystem-[contained-in]->software",
+				"operatingsystem-[contains]->centos7:107",
+				"operatingsystem-[contains]->centos6:106",
+				"operatingsystem-[contains]->centos5:105"
+		};
+		testEdges(input, nodes);
+	}
+
+	private void testEdges(String[] input, String[] expectedLines) {
+		List<Matcher<String>> matchers = joinAsIsMatchers(expectedLines);
+		runs = new Run[] {
+				new LineRun("edges", KitMatchers.inAnyOrder(matchers)),
+				new NoOutputRun("quit")
+		};
+		sessionTest(runs, Input.getFile(input));
+	}
+
+}

--- a/src/final1/subtests/ExportCommandTest.java
+++ b/src/final1/subtests/ExportCommandTest.java
@@ -1,0 +1,208 @@
+package final1.subtests;
+
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.Test;
+
+import test.Input;
+import test.KitMatchers;
+import test.SystemExitStatus;
+import test.runs.NoOutputRun;
+import test.runs.Run;
+
+/**
+ * Performs calls to the {@code export} command and checks the results.
+ */
+public class ExportCommandTest extends RecommendationSubtest {
+
+	public ExportCommandTest() {
+		setAllowedSystemExitStatus(SystemExitStatus.WITH_0);
+	}
+
+	/**
+	 * Asserts correct results for the example given on the task sheet.
+	 */
+	@Test
+	public void taskSheetExampleTest() {
+		testAgainstTaskSheet(TASK_SHEET_INPUT_FILE);
+		testAgainstTaskSheet(TASK_SHEET_INPUT_FILE_SPACES); // why not...
+	}
+
+	/**
+	 * Asserts correct results if the input file contains semantical duplicates.
+	 */
+	@Test
+	public void duplicatesTest() {
+		testAgainstTaskSheet(TASK_SHEET_INPUT_FILE_DUPLICATES);
+	}
+
+	private void testAgainstTaskSheet(String[] input) {
+		// expectedLines are taken from the task sheet, optionalLines not
+		String[] expectedLines = new String[] {
+				"libreoffice -> impress [label=haspart]",
+				"writer -> libreoffice [label=partof]",
+				"centos7 -> operatingsystem [label=containedin]",
+				"centos6 -> operatingsystem [label=containedin]",
+				"centos5 -> operatingsystem [label=containedin]",
+				"calc -> officesuite [label=containedin]",
+				"impress -> libreoffice [label=partof]",
+				"officesuite -> impress [label=contains]",
+				"libreoffice -> writer [label=haspart]",
+				"software -> operatingsystem [label=contains]",
+				"officesuite -> libreoffice [label=contains]",
+				"impress -> officesuite [label=containedin]",
+				"calc -> libreoffice [label=partof]",
+				"software -> officesuite [label=contains]",
+				"centos6 -> centos7 [label=predecessorof]",
+				"officesuite -> calc [label=contains]",
+				"operatingsystem -> centos5 [label=contains]",
+				"centos5 -> centos6 [label=predecessorof]",
+				"operatingsystem -> centos6 [label=contains]",
+				"libreoffice -> calc [label=haspart]",
+				"officesuite -> writer [label=contains]",
+				"libreoffice -> officesuite [label=containedin]",
+				"operatingsystem -> centos7 [label=contains]",
+				"writer -> officesuite [label=containedin]",
+				"centos7 -> centos6 [label=successorof]",
+				"officesuite -> software [label=containedin]",
+				"operatingsystem -> software [label=containedin]",
+				"centos6 -> centos5 [label=successorof]",
+				"software [shape=box]",
+				"officesuite [shape=box]",
+				"operatingsystem [shape=box]"
+		};
+		String[] optionalLines = new String[] {
+				"centos5",
+				"centos6",
+				"centos7",
+				"writer",
+				"calc",
+				"impress",
+				"libreoffice"
+		};
+		testExport(input, expectedLines, optionalLines);
+	}
+
+	private void testExport(String[] input, String[] expectedLines, String[] optionalLines) {
+		List<Matcher<String>> expectedResults = new ArrayList<>();
+		for (String line : expectedLines) {
+			expectedResults.add(leadingSpaces(line));
+		}
+		List<Matcher<String>> optionalResults = new ArrayList<>();
+		for (String line : optionalLines) {
+			optionalResults.add(leadingSpaces(line));
+		}
+
+		runs = new Run[] {
+				new ExportRun("export", expectedResults, optionalResults),
+				new NoOutputRun("quit")
+		};
+		sessionTest(runs, Input.getFile(input));
+	}
+
+	/**
+	 * Returns a matcher that accepts all strings that are {@code text} preceded with an arbitrary number of spaces
+	 * (including none).
+	 */
+	private static Matcher<String> leadingSpaces(final String expectedText) {
+		return new BaseMatcher<String>() {
+
+			@Override
+			public boolean matches(final Object testObject) {
+				String text = (String) testObject;
+				// it's unclear whether other whitespace (\s) is allowed as well
+				return text.matches(" *" + Pattern.quote(expectedText));
+			}
+
+			@Override
+			public void describeTo(Description description) {
+				description.appendText(" *" + expectedText);
+			}
+
+			@Override
+			public void describeMismatch(final Object item, final Description description) {
+				description.appendText("a string '" + expectedText + "' preceded with an arbitrary number of spaces");
+			}
+		};
+	}
+
+	class ExportRun implements Run {
+		private String command;
+		private List<Matcher<String>> expectedResults;
+		private Matcher<String> expectedMatcher;
+		private List<Matcher<String>> optionalResults;
+		private Matcher<String> optionalMatcher;
+
+		/**
+		 * Creates a test run that merges all call to {@code Terminal.printLine}. The run succeeds if the merged output
+		 * matches {@code expectedResults} line by line.
+		 * 
+		 * @param command
+		 *            The command to run
+		 * @param expectedResults
+		 *            The matchers describing the desired output
+		 */
+		public ExportRun(String command, List<Matcher<String>> expectedResults, List<Matcher<String>> optionalResults) {
+			this.command = command;
+			this.expectedResults = expectedResults;
+			this.optionalResults = optionalResults;
+			this.expectedMatcher = KitMatchers.anyOfRemaining(expectedResults);
+			this.optionalMatcher = KitMatchers.anyOfRemaining(optionalResults);
+		}
+
+		@Override
+		public String getCommand() {
+			return command;
+		}
+
+		@Override
+		public void check(String[] testedClassOutput, String errorMessage) {
+			StringBuilder mergedOutputBuilder = new StringBuilder();
+			for (String output : testedClassOutput) {
+				mergedOutputBuilder.append(output.replace("\r", ""));
+				mergedOutputBuilder.append("\n");
+			}
+			String[] outputLines = mergedOutputBuilder.toString().split("\n");
+
+			assertThat("First error at line 0: ", outputLines[0], is("digraph {"));
+			for (int i = 1; i < outputLines.length - 1; i++) {
+				String appendix = "\n First error at line " + i + ":";
+				assertThat(errorMessage + appendix, outputLines[i], anyOf(expectedMatcher, optionalMatcher));
+			}
+			assertThat("First error at last line: ", outputLines[outputLines.length - 1], is("}"));
+			if (!expectedResults.isEmpty()) {
+				fail("Did not contain these obligatory lines: " + expectedResults);
+			}
+		}
+
+		@Override
+		public String getExpectedDescription() {
+			StringBuilder resultBuilder = new StringBuilder();
+			for (Matcher<String> matcher : expectedResults) {
+				if (resultBuilder.length() > 0) {
+					resultBuilder.append("\n");
+				}
+				resultBuilder.append(matcher);
+			}
+			resultBuilder.append("\nand optional lines:\n");
+			for (Matcher<String> matcher : optionalResults) {
+				if (resultBuilder.length() > 0) {
+					resultBuilder.append("\n");
+				}
+				resultBuilder.append(matcher);
+			}
+			return resultBuilder.toString();
+		}
+	}
+
+}

--- a/src/final1/subtests/InvalidInputFileTest.java
+++ b/src/final1/subtests/InvalidInputFileTest.java
@@ -10,7 +10,7 @@ import test.SystemExitStatus;
 /**
  * Starts the program with several invalid input files without performing any actions. Checks if the program outputs
  * error messages.
- *
+ * 
  * @author Joshua Gleitze
  * @author Martin Loeper
  * @author Roman Langrehr
@@ -66,6 +66,11 @@ public class InvalidInputFileTest extends RecommendationSubtest {
 	public void invalidProductIds() {
 		input = new String[] {
 			"CentOS5 (id=1a2) contains operatingsystems"
+		};
+		errorTest("quit", Input.getFile(input));
+
+		input = new String[] {
+			"CentOS5 (id=-1) contains operatingsystems"
 		};
 		errorTest("quit", Input.getFile(input));
 

--- a/src/final1/subtests/InvalidRecommendTerms.java
+++ b/src/final1/subtests/InvalidRecommendTerms.java
@@ -48,6 +48,11 @@ public class InvalidRecommendTerms extends RecommendationSubtest {
 		errorTest(addQuit(commands), Input.getFile(TASK_SHEET_INPUT_FILE));
 
 		commands = new String[] {
+			"recommend S1 -1"
+		};
+		errorTest(addQuit(commands), Input.getFile(TASK_SHEET_INPUT_FILE));
+
+		commands = new String[] {
 			"recommend S1, 105"
 		};
 		errorTest(addQuit(commands), Input.getFile(TASK_SHEET_INPUT_FILE));

--- a/src/final1/subtests/InvalidRecommendTerms.java
+++ b/src/final1/subtests/InvalidRecommendTerms.java
@@ -9,11 +9,11 @@ import test.SystemExitStatus;
 
 /**
  * Launches the program with a valid input file and then tests some illegal recommend commands.
- *
+ * 
  * @author Roman Langrehr
  * @since 12.03.2015
  * @version 1.0
- *
+ * 
  */
 public class InvalidRecommendTerms extends RecommendationSubtest {
 	private String[] commands;
@@ -175,4 +175,31 @@ public class InvalidRecommendTerms extends RecommendationSubtest {
 		};
 		errorTest(addQuit(commands), Input.getFile(TASK_SHEET_INPUT_FILE));
 	}
+
+	/**
+	 * Tests for invalid spaces
+	 */
+	@Test
+	public void invalidSpaces() {
+		String[] variants = {
+				" recommend UNION(S1 201,INTERSECTION(S1 105,S3 107))",
+				"rec ommend UNION(S1 201,INTERSECTION(S1 105,S3 107))",
+				"recommend UNI ON(S1 201,INTERSECTION(S1 105,S3 107))",
+				"recommend UNION(S 1 201,INTERSECTION(S1 105,S3 107))",
+				"recommend UNION(S1 2 01,INTERSECTION(S1 105,S3 107))",
+				"recommend UNION(S1 201,INTERSECTION(S 1 105,S3 107))",
+				"recommend UNION(S1 201,INTERSECTION(S1 10 5,S3 107))",
+				"recommend UNION(S1 201,INTERSECTION(S1 105,S 3 107))",
+				"recommend UNION(S1 201,INTERSECTION(S1 105,S3 10 7))",
+				"recommend UNION(S1 201,INTERSECTI ON(S1 105,S3 107))",
+				"recommendUNION(S1 201,INTERSECTION(S1 105,S3 10 7))",
+				"recommend UNION(S1201,INTERSECTION(S1 105,S3 107))",
+				"recommend UNION(S1 201,INTERSECTION(S1105,S3 107))",
+				"recommend UNION(S1 201,INTERSECTION(S1 105,S3107))"
+		};
+		for (String variant : variants) {
+			errorTest(addQuit(variant), Input.getFile(TASK_SHEET_INPUT_FILE));
+		}
+	}
+
 }

--- a/src/final1/subtests/RecommendationSubtest.java
+++ b/src/final1/subtests/RecommendationSubtest.java
@@ -11,7 +11,7 @@ import test.TestObject;
 /**
  * Base class for implementing subtest for the programming lecture's first final task. Contains some convenience methods
  * and fields.
- *
+ * 
  * @author Joshua Gleitze
  * @author Martin Loeper
  * @version 1.1
@@ -85,6 +85,7 @@ public abstract class RecommendationSubtest extends InteractiveConsoleTest {
 	protected String[] ONE_LINE_INPUT_FILE1 = new String[] {
 		"B(id=1) successor-of A(id=2)"
 	};
+	// edges: new String[] { "b:1-[successor-of]->a", "a-[predecessor-of]->b" }
 
 	protected String[] ONE_LINE_INPUT_FILE2 = new String[] {
 		"A contains B(id=2)"
@@ -103,13 +104,70 @@ public abstract class RecommendationSubtest extends InteractiveConsoleTest {
 			"D (id=5) predecessor-of A (id=1)"
 	};
 
+	protected String[] COMPLEX_INPUT_FILE = new String[] {
+			"software contains vim(id=6)",
+			"software contains officesuite",
+			"software contains chromium(id=41)",
+			"officesuite contains libreoffice(id=333)",
+			"officesuite contains MSO(id=666666)",
+			"officesuite contained-in suite",
+			"suite contains distributions",
+			"suite contains libreoffice(id=333)",
+			"libreoffice(id=333) successor-of OOO(id=222)",
+			"writer(id=201) part-of libreoffice(id=333)",
+			"calc(id=202) part-of libreoffice(id=333)",
+			"impress(id=203) part-of libreoffice(id=333)",
+			"math(id=204) part-of libreoffice(id=333)",
+			"math(id=204) part-of writer(id=201)",
+			"OOO(id=222) has-part writer(id=201)",
+			"OOO(id=222) has-part calc(id=202)",
+			"OOO(id=222) has-part impress(id=203)",
+			"OOO(id=222) has-part math(id=204)",
+			"OOO(id=222) predecessor-of OracleOO(id=555)",
+			"OOO(id=222) predecessor-of AOO(id=444)",
+			"StarOffice(id=111) predecessor-of OOO(id=222)",
+			"chromium(id=41) has-part webkit(id=1)",
+			"webkit(id=1) part-of Blink(id=5)",
+			"Blink(id=5) successor-of webkit(id=1)",
+			"KHTML(id=4) predecessor-of webkit(id=1)",
+			"KJS(id=3) predecessor-of webkit(id=1)",
+			"webkit2(id=2) successor-of webkit(id=1)",
+			"distributions contains LinuxDistros",
+			"LinuxDistros contains Debian(id=78)",
+			"LinuxDistros contains DebBased",
+			"LinuxDistros contains Ub1204LTS(id=1204)",
+			"LinuxDistros contains Ub1210(id=1210)",
+			"LinuxDistros contains Ub1304(id=1304)",
+			"LinuxDistros contains Ub1310(id=1310)",
+			"LinuxDistros contains Ub1404LTS(id=1404)",
+			"apt(id=7) contained-in software",
+			"apt(id=7) part-of Debian(id=78)",
+			"DebBased contains Ub1204LTS(id=1204)",
+			"DebBased contains Ub1210(id=1210)",
+			"DebBased contains Ub1304(id=1304)",
+			"DebBased contains Ub1310(id=1310)",
+			"DebBased contains Ub1404LTS(id=1404)",
+			"DebBased contains Debian(id=78)",
+			"DebBased contains apt(id=7)",
+			"Ub1404LTS(id=1404) successor-of Ub1310(id=1310)",
+			"Ub1310(id=1310) successor-of Ub1304(id=1304)",
+			"Ub1304(id=1304) successor-of Ub1210(id=1210)",
+			"Ub1210(id=1210) successor-of Ub1204LTS(id=1204)",
+			"Ub1404LTS(id=1404) successor-of Ub1204LTS(id=1204)",
+			"god(id=0) successor-of Microsoft(id=69)",
+			"god(id=0) predecessor-of chucknorris(id=42)",
+			"Microsoft(id=69) part-of chucknorris(id=42)",
+			"chucknorris(id=42) predecessor-of evil(id=666)",
+			"evil(id=666) predecessor-of Hurd(id=1337)"
+	};
+
 	/**
 	 * Runs {@link #errorTest(String, String...)} with the provided arguments and asserts that {@code System.exit(x)}
 	 * was called with {@code x > 0} afterwards.
 	 * <p>
 	 * This method is deprecated as its function is now provided by
 	 * {@link InteractiveConsoleTest#setExpectedSystemStatus}
-	 *
+	 * 
 	 * @param command
 	 *            The command to run on the console.
 	 * @param args0
@@ -126,7 +184,7 @@ public abstract class RecommendationSubtest extends InteractiveConsoleTest {
 	 * <p>
 	 * This method is deprecated as its function is now provided by
 	 * {@link InteractiveConsoleTest#setExpectedSystemStatus}
-	 *
+	 * 
 	 * @param commands
 	 *            The commands to run on the console
 	 * @param args0

--- a/src/final1/subtests/RecommendationSubtest.java
+++ b/src/final1/subtests/RecommendationSubtest.java
@@ -91,6 +91,11 @@ public abstract class RecommendationSubtest extends InteractiveConsoleTest {
 		"A contains B(id=2)"
 	};
 
+	protected String[] ZERO_ID_INPUT_FILE = new String[] {
+			"A contains B(id=0)",
+			"A contains C(id=1)"
+	};
+
 	protected String[] PSEUDO_CIRCLE_INPUT_FILE1 = new String[] {
 			"A(id=1) successor-of B(id=2)",
 			"B(id=2) predecessor-of C(id=3)",

--- a/src/final1/subtests/RecommendationSubtest.java
+++ b/src/final1/subtests/RecommendationSubtest.java
@@ -85,7 +85,6 @@ public abstract class RecommendationSubtest extends InteractiveConsoleTest {
 	protected String[] ONE_LINE_INPUT_FILE1 = new String[] {
 		"B(id=1) successor-of A(id=2)"
 	};
-	// edges: new String[] { "b:1-[successor-of]->a", "a-[predecessor-of]->b" }
 
 	protected String[] ONE_LINE_INPUT_FILE2 = new String[] {
 		"A contains B(id=2)"

--- a/src/final1/subtests/ValidInputFileTest.java
+++ b/src/final1/subtests/ValidInputFileTest.java
@@ -41,8 +41,8 @@ public class ValidInputFileTest extends RecommendationSubtest {
 	}
 
 	/**
-	 * Asserts that the tested class is able to read in input files that define relations that may easily be confused
-	 * with circles.
+	 * Asserts that the tested class is able to read input files that define relations that may easily be confused with
+	 * circles.
 	 */
 	@Test
 	public void pseudoCirclesTest() {

--- a/src/final1/subtests/ValidInputFileTest.java
+++ b/src/final1/subtests/ValidInputFileTest.java
@@ -77,6 +77,14 @@ public class ValidInputFileTest extends RecommendationSubtest {
 	}
 
 	/**
+	 * Asserts that 0 is a valid product ID.
+	 */
+	@Test
+	public void zeroIdTest() {
+		noOutputTest("quit", Input.getFile(ZERO_ID_INPUT_FILE));
+	}
+
+	/**
 	 * Asserts that the tested class is able to read in input files that have keywords as shop element names.
 	 */
 	@Test

--- a/src/final1/subtests/ValidInputFileTest.java
+++ b/src/final1/subtests/ValidInputFileTest.java
@@ -10,7 +10,7 @@ import test.SystemExitStatus;
 /**
  * Starts the program with several valid input files without performing any actions. Checks if the tested class is able
  * to read in the files without output, exceptions or a call to {@code System.exit(x)} with {@code x>0}.
- *
+ * 
  * @author Joshua Gleitze
  * @author Martin Loeper
  * @version 1.1
@@ -92,6 +92,11 @@ public class ValidInputFileTest extends RecommendationSubtest {
 				"contains (id=1) part-of dump(id=2)"
 		};
 		noOutputTest("quit", Input.getFile(input));
+	}
+
+	@Test
+	public void complexTest() {
+		noOutputTest("quit", Input.getFile(COMPLEX_INPUT_FILE));
 	}
 
 	@Test

--- a/src/final1/subtests/ValidNodesCommandTest.java
+++ b/src/final1/subtests/ValidNodesCommandTest.java
@@ -1,20 +1,20 @@
 package final1.subtests;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.fail;
 
+import java.util.List;
+
+import org.hamcrest.Matcher;
 import org.junit.Test;
 
 import test.Input;
 import test.SystemExitStatus;
-import test.runs.ErrorRun;
-import test.runs.ExactRun;
-import test.runs.NoOutputRun;
-import test.runs.Run;
 
 /**
  * Performs valid calls to the {@code nodes} command and checks the results.
- *
+ * 
  * @author Joshua Gleitze
  * @author Martin Loeper
  * @version 1.1
@@ -42,7 +42,7 @@ public class ValidNodesCommandTest extends RecommendationSubtest {
 	}
 
 	/**
-	 * Asserts correct results if the input file contains semantically dublicates.
+	 * Asserts correct results if the input file contains semantical duplicates.
 	 */
 	@Test
 	public void duplicatesTest() {
@@ -55,31 +55,17 @@ public class ValidNodesCommandTest extends RecommendationSubtest {
 	 */
 	@Test
 	public void oneLineTest() {
-		// @formatter:off
 		runs = new Run[] {
-			new ExactRun("nodes", is("a:2,b:1")),
-			new ExactRun("recommend S1 1", is("")),
-			new ErrorRun("recommend S1 3"),
-			new ErrorRun("recommend S4 1"),
-			new ExactRun("recommend S2 1", is("")),
-			new ExactRun("recommend S2 2", is("b:1")),
-			new ErrorRun("redbutton"),
-			new ExactRun("recommend S3 1", is("a:2")),
-			new ExactRun("recommend S3 2", is("")),
-			new NoOutputRun("quit")
-		};
-		// edges: new String[] { "b:1-[successor-of]->a", "a-[predecessor-of]->b" }
-		sessionTest(runs, Input.getFile(ONE_LINE_INPUT_FILE1));
-
-		runs = new Run[] {
-				new ExactRun("nodes", is("a,b:2")),
-				new ErrorRun("recommend S1 1"),
-				new ExactRun("recommend S1 2", is("")),
-				new ExactRun("recommend S2 1", is("")),
-				new ExactRun("recommend S3 1", is("")),
+				new ExactRun("nodes", is("a:2,b:1")),
 				new NoOutputRun("quit")
 		};
-		sessionTest(runs, Input.getFile(ONE_LINE_INPUT_FILE2));
+ 		sessionTest(runs, Input.getFile(ONE_LINE_INPUT_FILE1));
+ 
+		runs = new Run[] {
+				new ExactRun("nodes", is("a,b:2")),
+				new NoOutputRun("quit")
+		};
+ 		sessionTest(runs, Input.getFile(ONE_LINE_INPUT_FILE2));
 	}
 
 	private void testAgainstTaskSheet(String[] input) {
@@ -103,4 +89,5 @@ public class ValidNodesCommandTest extends RecommendationSubtest {
 	public void incomplete() {
 		fail("This test is still in the development state and therefore incomplete!");
 	}
+
 }

--- a/src/final1/subtests/ValidNodesCommandTest.java
+++ b/src/final1/subtests/ValidNodesCommandTest.java
@@ -1,16 +1,15 @@
 package final1.subtests;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.fail;
 
-import java.util.List;
-
-import org.hamcrest.Matcher;
 import org.junit.Test;
 
 import test.Input;
 import test.SystemExitStatus;
+import test.runs.ExactRun;
+import test.runs.NoOutputRun;
+import test.runs.Run;
 
 /**
  * Performs valid calls to the {@code nodes} command and checks the results.
@@ -50,8 +49,7 @@ public class ValidNodesCommandTest extends RecommendationSubtest {
 	}
 
 	/**
-	 * Asserts overall correct behaviour of the implementation. This includes several error detection and recovery after
-	 * errors.
+	 * Asserts correct results for simple one line input files.
 	 */
 	@Test
 	public void oneLineTest() {
@@ -59,29 +57,31 @@ public class ValidNodesCommandTest extends RecommendationSubtest {
 				new ExactRun("nodes", is("a:2,b:1")),
 				new NoOutputRun("quit")
 		};
- 		sessionTest(runs, Input.getFile(ONE_LINE_INPUT_FILE1));
- 
+		sessionTest(runs, Input.getFile(ONE_LINE_INPUT_FILE1));
+
 		runs = new Run[] {
 				new ExactRun("nodes", is("a,b:2")),
 				new NoOutputRun("quit")
 		};
- 		sessionTest(runs, Input.getFile(ONE_LINE_INPUT_FILE2));
+		sessionTest(runs, Input.getFile(ONE_LINE_INPUT_FILE2));
+	}
+
+	/**
+	 * Asserts that product ID 0 can be handled correctly.
+	 */
+	@Test
+	public void zeroIdTest() {
+		oneLineTest(addQuit("nodes"), "a,b:0,c:1", Input.getFile(ZERO_ID_INPUT_FILE));
 	}
 
 	private void testAgainstTaskSheet(String[] input) {
-		//@formatter:off
-
-        // the following queries/matchers are taken directly from the task sheet
+		// the following queries/matchers are taken directly from the task sheet
 		runs = new Run[] {
-			new ExactRun("nodes", is("calc:202,centos5:105,centos6:106,centos7:107,impress:203,libreoffice:200,officesuite,operatingsystem,software,writer:201")),
-			new ExactRun("recommend S1 105", is("centos6:106,centos7:107")),
-			new ExactRun("recommend S3 107", is("centos5:105,centos6:106")),
-			new ExactRun("recommend UNION(S1 105,S3 107)", is("centos5:105,centos6:106,centos7:107")),
-			new ExactRun("recommend S1 201", is("calc:202,impress:203,libreoffice:200")),
-			new ExactRun("recommend UNION(S1 201,INTERSECTION(S1 105,S3 107))", is("calc:202,centos6:106,impress:203,libreoffice:200")),
-			new NoOutputRun("quit")
+				new ExactRun(
+						"nodes",
+						is("calc:202,centos5:105,centos6:106,centos7:107,impress:203,libreoffice:200,officesuite,operatingsystem,software,writer:201")),
+				new NoOutputRun("quit")
 		};
-		//@formatter:on
 		sessionTest(runs, Input.getFile(input));
 	}
 

--- a/src/final1/subtests/ValidRecommendCommandTest.java
+++ b/src/final1/subtests/ValidRecommendCommandTest.java
@@ -1,0 +1,230 @@
+package final1.subtests;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hamcrest.Matcher;
+import org.junit.Test;
+
+import test.Input;
+import test.SystemExitStatus;
+
+/**
+ * Performs valid calls to the {@code recommend} command and checks the results.
+ * 
+ */
+public class ValidRecommendCommandTest extends RecommendationSubtest {
+
+	public ValidRecommendCommandTest() {
+		setAllowedSystemExitStatus(SystemExitStatus.WITH_0);
+	}
+
+	/**
+	 * Asserts correct results for the example given on the task sheet.
+	 */
+	@Test
+	public void taskSheetExampleTest() {
+		testAgainstTaskSheet(TASK_SHEET_INPUT_FILE);
+	}
+
+	/**
+	 * Asserts correct results if the input file contains spaces.
+	 */
+	@Test
+	public void spacesTest() {
+		testAgainstTaskSheet(TASK_SHEET_INPUT_FILE_SPACES);
+	}
+
+	/**
+	 * Asserts correct results if the input file contains semantical duplicates.
+	 */
+	@Test
+	public void duplicatesTest() {
+		testAgainstTaskSheet(TASK_SHEET_INPUT_FILE_DUPLICATES);
+	}
+
+	/**
+	 * Asserts overall correct behaviour of the implementation. This includes several error detection and recovery after
+	 * errors.
+	 */
+	@Test
+	public void oneLineTest() {
+		String[] queries = new String[] {
+				"recommend S1 1",
+				"recommend S1 3",
+				"recommend S4 1",
+				"recommend S2 1",
+				"recommend S2 2",
+				"redbutton",
+				"recommend S3 1",
+				"recommend S3 2"
+		};
+		// @formatter:off
+		List<Matcher<String>> matchers = getMatchers(
+			is(""),
+			startsWith("Error,"),
+			startsWith("Error,"),
+			is(""),
+			is("b:1"),
+			startsWith("Error,"),
+			is("a:2"),
+			is("")
+		);
+		// @formatter:on
+		// edges: new String[] { "b:1-[successor-of]->a", "a-[predecessor-of]->b" }
+		multiLineTest(addQuit(queries), matchers, Input.getFile(ONE_LINE_INPUT_FILE1));
+
+		queries = new String[] {
+				"recommend S1 1",
+				"recommend S1 2",
+				"recommend S2 2",
+				"recommend S3 2",
+		};
+		// @formatter:off
+        matchers = getMatchers(
+            startsWith("Error,"),
+            is(""),
+            is(""),
+            is("")
+        );
+        // @formatter:on
+		multiLineTest(addQuit(queries), matchers, Input.getFile(ONE_LINE_INPUT_FILE2));
+	}
+
+	private void testAgainstTaskSheet(String[] input) {
+		// the following queries/matchers are taken directly from the task sheet
+		String[] queries = new String[] {
+				"recommend S1 105",
+				"recommend S3 107",
+				"recommend UNION(S1 105,S3 107)",
+				"recommend S1 201",
+				"recommend UNION(S1 201,INTERSECTION(S1 105,S3 107))",
+		};
+		// @formatter:off
+        List<Matcher<String>> matchers = getMatchers(
+            is("centos6:106,centos7:107"),
+            is("centos5:105,centos6:106"),
+            is("centos5:105,centos6:106,centos7:107"),
+            is("calc:202,impress:203,libreoffice:200"),
+            is("calc:202,centos6:106,impress:203,libreoffice:200")
+        );
+        // @formatter:on
+		multiLineTest(addQuit(queries), matchers, Input.getFile(input));
+	}
+
+	@Test
+	public void complexRecommendTest() {
+		String[][] commandResultArray = new String[][] {
+				{
+						"S1 7",
+						"chromium:41,debian:78,ub1204lts:1204,ub1210:1210,ub1304:1304,ub1310:1310,ub1404lts:1404,vim:6"
+				},
+				{
+						"S1 333",
+						"mso:666666"
+				},
+				{
+						"S2 222",
+						"aoo:444,libreoffice:333,oracleoo:555"
+				},
+				{
+						"S2 111",
+						"aoo:444,libreoffice:333,ooo:222,oracleoo:555"
+				},
+				{
+						"S2 555",
+						""
+				},
+				{
+						"S3 222",
+						"staroffice:111"
+				},
+				{
+						"S3 555",
+						"ooo:222,staroffice:111"
+				},
+				{
+						"S2 4",
+						"blink:5,webkit:1,webkit2:2"
+				},
+				{
+						"S3 333",
+						"ooo:222,staroffice:111"
+				},
+				{
+						"S3 5",
+						"khtml:4,kjs:3,webkit:1"
+				},
+				{
+						"S3 4",
+						""
+				},
+				{
+						"S3 3",
+						""
+				},
+				{
+						"INTERSECTION(S3 4, S3 3)",
+						""
+				},
+				{
+						"UNION(S3 4, S3 3)",
+						""
+				},
+				{
+						"UNION(INTERSECTION(S3 4, S3 3), UNION(S3 4, S3 3))",
+						""
+				},
+				{
+						"INTERSECTION(INTERSECTION(S3 4, S3 3), UNION(S3 4, S3 3))",
+						""
+				},
+				{
+						"S2 69",
+						"chucknorris:42,evil:666,god:0,hurd:1337"
+				},
+				{
+						"S2 1337",
+						""
+				},
+				{
+						"S3 1337",
+						"chucknorris:42,evil:666,god:0,microsoft:69"
+				},
+				{
+						"INTERSECTION(S2 69, S3 1337)",
+						"chucknorris:42,evil:666,god:0"
+				},
+				{
+						"UNION(S2 69, S3 1337)",
+						"chucknorris:42,evil:666,god:0,hurd:1337,microsoft:69"
+				},
+				{
+						"UNION(UNION(S2 69, S3 1337), UNION(INTERSECTION(INTERSECTION(S3 4, S3 3), UNION(S3 4, S3 3)), UNION(S2 111, UNION(S3 222, UNION(S1 1404, S2 1310)))))",
+						"aoo:444,apt:7,chucknorris:42,debian:78,evil:666,god:0,hurd:1337,libreoffice:333,microsoft:69,ooo:222,oracleoo:555,staroffice:111,ub1204lts:1204,ub1210:1210,ub1304:1304,ub1310:1310,ub1404lts:1404"
+				},
+				{
+						"INTERSECTION(UNION(S2 69, S3 1337), UNION(INTERSECTION(INTERSECTION(S3 4, S3 3), UNION(S3 4, S3 3)), UNION(S2 111, UNION(S3 222, UNION(S1 1404, S2 1310)))))",
+						""
+				}
+		};
+
+		String queries[] = new String[commandResultArray.length];
+		List<Matcher<String>> matchers = new ArrayList<>();
+		for (int i = 0; i < commandResultArray.length; i++) {
+			queries[i] = "recommend " + commandResultArray[i][0];
+			matchers.add(is(commandResultArray[i][1]));
+		}
+		multiLineTest(addQuit(queries), matchers, Input.getFile(COMPLEX_INPUT_FILE));
+	}
+
+	@Test
+	public void incomplete() {
+		fail("This test is still in the development state and therefore incomplete!");
+	}
+
+}

--- a/src/final1/subtests/ValidRecommendCommandTest.java
+++ b/src/final1/subtests/ValidRecommendCommandTest.java
@@ -2,7 +2,6 @@ package final1.subtests;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -137,6 +136,22 @@ public class ValidRecommendCommandTest extends RecommendationSubtest {
 		multiLineTest(addQuit(queries), matchers, Input.getFile(ONE_LINE_INPUT_FILE2));
 	}
 
+	/**
+	 * Asserts that product ID 0 can be handled correctly.
+	 */
+	@Test
+	public void zeroIdTest() {
+		multiLineTest(addQuit(new String[] {
+				"recommend S1 0",
+				"recommend S1 1",
+				"recommend S2 0"
+		}), new String[] {
+				"c:1",
+				"b:0",
+				""
+		}, Input.getFile(ZERO_ID_INPUT_FILE));
+	}
+
 	@Test
 	public void complexTest() {
 		String[][] commandResultArray = new String[][] {
@@ -241,11 +256,6 @@ public class ValidRecommendCommandTest extends RecommendationSubtest {
 			matchers.add(is(commandResultArray[i][1]));
 		}
 		multiLineTest(addQuit(queries), matchers, Input.getFile(COMPLEX_INPUT_FILE));
-	}
-
-	@Test
-	public void incomplete() {
-		fail("This test is still in the development state and therefore incomplete!");
 	}
 
 }

--- a/src/final1/subtests/ValidRecommendCommandTest.java
+++ b/src/final1/subtests/ValidRecommendCommandTest.java
@@ -29,14 +29,7 @@ public class ValidRecommendCommandTest extends RecommendationSubtest {
 	@Test
 	public void taskSheetExampleTest() {
 		testAgainstTaskSheet(TASK_SHEET_INPUT_FILE);
-	}
-
-	/**
-	 * Asserts correct results if the input file contains spaces.
-	 */
-	@Test
-	public void spacesTest() {
-		testAgainstTaskSheet(TASK_SHEET_INPUT_FILE_SPACES);
+		testAgainstTaskSheet(TASK_SHEET_INPUT_FILE_SPACES); // Not sure if this is really needed
 	}
 
 	/**
@@ -45,6 +38,55 @@ public class ValidRecommendCommandTest extends RecommendationSubtest {
 	@Test
 	public void duplicatesTest() {
 		testAgainstTaskSheet(TASK_SHEET_INPUT_FILE_DUPLICATES);
+	}
+
+	private void testAgainstTaskSheet(String[] input) {
+		// the following queries/matchers are taken directly from the task sheet
+		String[] queries = new String[] {
+				"recommend S1 105",
+				"recommend S3 107",
+				"recommend UNION(S1 105,S3 107)",
+				"recommend S1 201",
+				"recommend UNION(S1 201,INTERSECTION(S1 105,S3 107))",
+		};
+		// @formatter:off
+        List<Matcher<String>> matchers = getMatchers(
+            is("centos6:106,centos7:107"),
+            is("centos5:105,centos6:106"),
+            is("centos5:105,centos6:106,centos7:107"),
+            is("calc:202,impress:203,libreoffice:200"),
+            is("calc:202,centos6:106,impress:203,libreoffice:200")
+        );
+        // @formatter:on
+		multiLineTest(addQuit(queries), matchers, Input.getFile(input));
+	}
+
+	/**
+	 * Asserts correct results for different variations of spaces in the recommend command.
+	 */
+	@Test
+	public void spacesTest() {
+		String[] variants = {
+				"recommend UNION(S1 201,INTERSECTION(S1 105,S3 107))",
+				"recommend  UNION  (S1 201,INTERSECTION(S1 105,S3 107))",
+				"recommend UNION  (S1 201,INTERSECTION(S1 105,S3 107))",
+				"recommend UNION(S1  201,INTERSECTION(S1 105,S3 107))",
+				"recommend UNION(S1 201  ,INTERSECTION(S1 105,S3 107))",
+				"recommend UNION(S1 201,  INTERSECTION(S1 105,S3 107))",
+				"recommend UNION(S1 201,INTERSECTION  (S1 105,S3 107))",
+				"recommend UNION(S1 201,INTERSECTION(  S1 105,S3 107))",
+				"recommend UNION(S1 201,INTERSECTION(S1 105   ,S3 107))",
+				"recommend UNION(S1 201,INTERSECTION(S1   105,  S3 107))",
+				"recommend UNION(S1 201,INTERSECTION(S1 105,S3  107))",
+				"recommend UNION(S1 201,INTERSECTION(S1 105,S3 107  ))",
+				"recommend UNION(S1 201,INTERSECTION(S1 105,S3 107)  )",
+				"recommend UNION(S1 201,INTERSECTION(S1 105,S3 107))  ",
+				"recommend        UNION      (     S1     201    ,    INTERSECTION    (    S1    105   ,   S3    107    )    )     "
+		};
+		for (String variant : variants) {
+			oneLineTest(addQuit(variant), "calc:202,centos6:106,impress:203,libreoffice:200",
+				Input.getFile(TASK_SHEET_INPUT_FILE));
+		}
 	}
 
 	/**
@@ -95,29 +137,8 @@ public class ValidRecommendCommandTest extends RecommendationSubtest {
 		multiLineTest(addQuit(queries), matchers, Input.getFile(ONE_LINE_INPUT_FILE2));
 	}
 
-	private void testAgainstTaskSheet(String[] input) {
-		// the following queries/matchers are taken directly from the task sheet
-		String[] queries = new String[] {
-				"recommend S1 105",
-				"recommend S3 107",
-				"recommend UNION(S1 105,S3 107)",
-				"recommend S1 201",
-				"recommend UNION(S1 201,INTERSECTION(S1 105,S3 107))",
-		};
-		// @formatter:off
-        List<Matcher<String>> matchers = getMatchers(
-            is("centos6:106,centos7:107"),
-            is("centos5:105,centos6:106"),
-            is("centos5:105,centos6:106,centos7:107"),
-            is("calc:202,impress:203,libreoffice:200"),
-            is("calc:202,centos6:106,impress:203,libreoffice:200")
-        );
-        // @formatter:on
-		multiLineTest(addQuit(queries), matchers, Input.getFile(input));
-	}
-
 	@Test
-	public void complexRecommendTest() {
+	public void complexTest() {
 		String[][] commandResultArray = new String[][] {
 				{
 						"S1 7",

--- a/src/test/InteractiveConsoleTest.java
+++ b/src/test/InteractiveConsoleTest.java
@@ -44,12 +44,12 @@ import test.runs.Run;
  * To use the new way, call {@link #setAllowedSystemExitStatus(SystemExitStatus)} or
  * {@link #setExpectedSystemStatus(SystemExitStatus)} before running one of the test methods. Typically, a test class
  * does this once in its constructor.
- *
+ * 
  * @author Roman Langrehr
  * @author Joshua Gleitze
  * @since 05.01.2015
  * @version 1.3
- *
+ * 
  */
 public abstract class InteractiveConsoleTest {
 	/**
@@ -95,7 +95,7 @@ public abstract class InteractiveConsoleTest {
 
 	/**
 	 * Adds the "quit" command to the given {@code commands}.
-	 *
+	 * 
 	 * @param commands
 	 *            The commands to add {@code quit} to.
 	 * @return A copy of {@code commands} with {@code "quit"} added to its end
@@ -171,7 +171,7 @@ public abstract class InteractiveConsoleTest {
 	/**
 	 * The message that should be printed at the start of an error message. Override this method to print your own
 	 * message.
-	 *
+	 * 
 	 * @param commands
 	 *            the commands that were run on the interactive console
 	 * @param commandLineArguments
@@ -191,7 +191,7 @@ public abstract class InteractiveConsoleTest {
 	 * called {@code Terminal.printLine} at least once and the output starts with {@code "Error,"}. <br>
 	 * NOTE: This method does <b>not</b> allow to call {@code System.exit(1)}. If you expect the implemented class to do
 	 * so, call {@code TestObject.allowSystemExit(SystemExitStatus.WITH_GREATER_THAN_0);} before.
-	 *
+	 * 
 	 * @param command
 	 *            The command to run on the console.
 	 * @param args0
@@ -207,7 +207,7 @@ public abstract class InteractiveConsoleTest {
 	 * tested class called {@code Terminal.printLine} at least once and the output starts with {@code "Error,"}.<br>
 	 * NOTE: This method does <b>not</b> allow to call {@code System.exit(1)}. If you expect the implemented class to do
 	 * so, call {@code TestObject.allowSystemExit(SystemExitStatus.WITH_GREATER_THAN_0);} before.
-	 *
+	 * 
 	 * @param commands
 	 *            The commands to run on the console
 	 * @param args0
@@ -232,7 +232,7 @@ public abstract class InteractiveConsoleTest {
 	 * A representation of command line arguments. Returns {@code that has been called with the command line arguments},
 	 * concatenated with a list representation of {@code commandLineArguments}. Returns an empty String if
 	 * {@code commandLineArguments} is {@code null} or empty.
-	 *
+	 * 
 	 * @param commandLineArguments
 	 *            the cli arguments to process
 	 * @return a String represention {@code commandLineArguments}
@@ -247,7 +247,7 @@ public abstract class InteractiveConsoleTest {
 	/**
 	 * Constructs a List of matchers to be used for the {@link #multiLineTest} methods. This method can be used to write
 	 * down expected output nicely, one Matcher per line. For example:
-	 *
+	 * 
 	 * <pre>
 	 * <code>
 	 * 	// @formatter:off
@@ -259,7 +259,7 @@ public abstract class InteractiveConsoleTest {
 	 * 	// @formatter:on
 	 * </code>
 	 * </pre>
-	 *
+	 * 
 	 * @param matchers
 	 *            the matchers to construct the list.
 	 * @return a list containing {@code matchers}
@@ -272,7 +272,7 @@ public abstract class InteractiveConsoleTest {
 	/**
 	 * Initiates the new way of system exit status checking. Has to be called before the first call to a
 	 * {@link TestObject} run method.
-	 *
+	 * 
 	 * @throws IllegalStateException
 	 *             If this method has already been called without a subsequent call to
 	 *             {@link #checkSystemExitStatus(String[], String[])}.
@@ -298,7 +298,7 @@ public abstract class InteractiveConsoleTest {
 	 * Example:<br>
 	 * Say we expect the main method to output three times {@code "Success!"} and then a line starting with
 	 * {@code "Error,"}. The call would work like this: <br>
-	 *
+	 * 
 	 * <pre>
 	 * <code>
 	 * {@code
@@ -311,7 +311,7 @@ public abstract class InteractiveConsoleTest {
 	 * }
 	 * </code>
 	 * </pre>
-	 *
+	 * 
 	 * @param command
 	 *            The command to run on the console.
 	 * @param expectedResults
@@ -329,7 +329,7 @@ public abstract class InteractiveConsoleTest {
 	 * with optional {@code args0} on the test object and runs all {@code commands} on it. Asserts that each output line
 	 * matches the {@code expectedResults}. Make sure to provide exactly one {@link Matcher} for each output line you
 	 * expect.
-	 *
+	 * 
 	 * @param command
 	 *            The command to run on the console.
 	 * @param expectedResults
@@ -405,7 +405,7 @@ public abstract class InteractiveConsoleTest {
 	 * method with optional {@code args0} on the test object and runs all {@code commands} on it. Asserts that each
 	 * output line matches the {@code expectedResults}. Make sure to provide exactly one {@link Matcher} for each output
 	 * line you expect.
-	 *
+	 * 
 	 * @param commands
 	 *            The commands to run on the console.
 	 * @param expectedResults
@@ -422,7 +422,7 @@ public abstract class InteractiveConsoleTest {
 	 * Tests an interactive console program with one command that should not output anything. Calls the main method with
 	 * optional {@code args0} on the test object and runs {@code command} on it. Asserts that the tested class never
 	 * called {@code Terminal.printLine}.
-	 *
+	 * 
 	 * @param command
 	 *            The command to run on the test object.
 	 * @param args0
@@ -436,7 +436,7 @@ public abstract class InteractiveConsoleTest {
 	 * Tests an interactive console program with multiple commands that should not output anything. Calls the main
 	 * method with optional {@code args0} on the test object and runs all {@code commands} on it. Asserts that the
 	 * tested class never called {@code Terminal.printLine}.
-	 *
+	 * 
 	 * @param commands
 	 *            The commands to run on the test object.
 	 * @param args0
@@ -461,7 +461,7 @@ public abstract class InteractiveConsoleTest {
 	 * Tests an interactive console program with one command that should output one line. Calls the main method with
 	 * optional {@code args0} on the test object and runs all {@code commands} on it. Asserts that the tested class only
 	 * called {@code Terminal.printLine} once and the output matches the {@code expectedOutputMatcher}.
-	 *
+	 * 
 	 * @param command
 	 *            The command to run on the console.
 	 * @param expectedOutputMatcher
@@ -477,7 +477,7 @@ public abstract class InteractiveConsoleTest {
 	 * Test an interactive console program with one command that should output one line. Calls the main method with
 	 * optional {@code args0} on the test object and runs all {@code commands} on it. Asserts that the tested class
 	 * called {@code Terminal.printLine} only once and the output was exactly {@code expectedOutput}.
-	 *
+	 * 
 	 * @param command
 	 *            The command to run on the console.
 	 * @param expectedOutput
@@ -493,7 +493,7 @@ public abstract class InteractiveConsoleTest {
 	 * Tests an interactive console program with multiple commands that should output one line. Calls the main method
 	 * with optional {@code args0} on the test object and runs all {@code commands} on it. Asserts that the tested class
 	 * called {@code Terminal.printLine} only once and the output matches the {@code expectedOutputMatcher}.
-	 *
+	 * 
 	 * @param commands
 	 *            The commands to run on the test object.
 	 * @param expectedOutputMatcher
@@ -581,7 +581,7 @@ public abstract class InteractiveConsoleTest {
 	 * Tests an interactive console program with multiple commands that should output one line. Calls the main method
 	 * with optional {@code args0} on the test object and runs all {@code commands} on it. Asserts that the tested class
 	 * called {@code Terminal.printLine} only once and the output was exactly {@code expectedOutput}.
-	 *
+	 * 
 	 * @param commands
 	 *            The commands to run on the test object.
 	 * @param expectedOutput
@@ -601,7 +601,7 @@ public abstract class InteractiveConsoleTest {
 	 * <p>
 	 * NOTE: This setting only takes effect if {@link #setExpectedSystemStatus(SystemExitStatus)} was called with
 	 * {@code null}!
-	 *
+	 * 
 	 * @param status
 	 *            The {@code x} the tested class may {@code System.exit} with. {@code null} to disable the new way of
 	 *            system exit status checking.
@@ -617,7 +617,7 @@ public abstract class InteractiveConsoleTest {
 	 * <p>
 	 * NOTE: This setting overrides {@link #setAllowedSystemExitStatus(SystemExitStatus)}: The allowed system exit
 	 * status is ignored as long as the expected status is not {@code null}.
-	 *
+	 * 
 	 * @param status
 	 *            The {@code x} the tested class has to call {@code System.exit} with. Set to {@code null} if the tested
 	 *            class does not necessary have to call {@code System.exit}.
@@ -637,7 +637,7 @@ public abstract class InteractiveConsoleTest {
 		};
 	}
 
-	private List<Matcher<String>> joinAsIsMatchers(String[] strings) {
+	protected List<Matcher<String>> joinAsIsMatchers(String[] strings) {
 		List<Matcher<String>> result = new Vector<Matcher<String>>();
 		for (String s : strings) {
 			result.add(is(s));

--- a/src/test/KitMatchers.java
+++ b/src/test/KitMatchers.java
@@ -10,7 +10,7 @@ import org.hamcrest.Matcher;
 
 /**
  * Contains Matchers that are not provided {@code #org.hamcrest.CoreMatchers} but needed by a test.
- *
+ * 
  * @author Joshua Gleitze
  * @version 1.0
  * @since 02.02.2015
@@ -20,7 +20,7 @@ public class KitMatchers {
 	/**
 	 * Creates a matcher that matches if the examined String contains exactly the elements in the specified String
 	 * Array, separated exactly by {@code divider}.
-	 *
+	 * 
 	 * @param substrings
 	 *            the substrings that the returned matcher will expect to be contained by any examined string
 	 * @param divider
@@ -118,7 +118,7 @@ public class KitMatchers {
 	 * Creates a matcher that matches if the examined String array contains exactly as much elements as specified by
 	 * {@code outputLines}. This matcher is meant to assert a tested class' output. It provides a appropriate error
 	 * message.
-	 *
+	 * 
 	 * @param outputLines
 	 *            How many lines the tested class should print.
 	 * @param outputDescription
@@ -141,8 +141,11 @@ public class KitMatchers {
 
 			@Override
 			public void describeMismatch(final Object item, final Description description) {
-				description.appendText("found ").appendText((providedLines.length == 1) ? " call" : " calls")
-						.appendText(" to Terminal.printLine");
+				description
+						.appendText("found " + providedLines.length)
+						.appendText((providedLines.length == 1) ? " call" : " calls")
+						.appendText(
+							" to Terminal.printLine or (depending on the test) lines that were printed using (possibly multiple) calls to Terminal.printLine");
 			}
 
 		};
@@ -175,4 +178,13 @@ public class KitMatchers {
 
 		};
 	}
+
+	public static List<Matcher<String>> inAnyOrder(List<Matcher<String>> expectedOutput) {
+		List<Matcher<String>> result = new LinkedList<>();
+		for (int i = 0; i < expectedOutput.size(); i++) {
+			result.add(KitMatchers.anyOfRemaining(expectedOutput));
+		}
+		return result;
+	}
+
 }

--- a/src/test/runs/LineRun.java
+++ b/src/test/runs/LineRun.java
@@ -81,7 +81,7 @@ public class LineRun implements Run {
 	}
 
 	private String lineCountMessage() {
-		return "exactly " + ((expectedResults.size() == 1) ? "line" : "lines");
+		return "exactly " + expectedResults.size() + " " + ((expectedResults.size() == 1) ? "line" : "lines");
 	}
 
 	/*


### PR DESCRIPTION
This is not quite done yet (needs nodes/edges/export tests), but wanted to share this more complex recommend test.
That `String queries[]`/`List<Matcher<String>> matchers` snippet would probably be better off as a general helper method but… but "it works".

This graph could be used for other advanced tests, as it has quite some special properties.
Here's the graphviz representation (thanks to the dot export; boo for most image hosters not supporting svg):
![COMPLEX_INPUT_FILE dot representation](https://cloud.githubusercontent.com/assets/1506734/6632503/ab375d38-c937-11e4-9aa2-43c102d77109.png)
(It looks more clear on my sheet of paper though.)

Didn't use formatter/cleanup tools because of the problems mentioned in #57.
