### PR TITLE
Set exact system exit value

### DIFF
--- a/src/final1/subtests/InvalidCommandLineArgumentsTest.java
+++ b/src/final1/subtests/InvalidCommandLineArgumentsTest.java
@@ -15,7 +15,7 @@ import test.SystemExitStatus;
 public class InvalidCommandLineArgumentsTest extends RecommendationSubtest {
 
 	public InvalidCommandLineArgumentsTest() {
-		setExpectedSystemStatus(SystemExitStatus.WITH_GREATER_THAN_0);
+		setExpectedSystemStatus(SystemExitStatus.EXACTLY.status(1));
 	}
 
 	/**

--- a/src/final1/subtests/InvalidInputFileTest.java
+++ b/src/final1/subtests/InvalidInputFileTest.java
@@ -20,7 +20,7 @@ public class InvalidInputFileTest extends RecommendationSubtest {
 	private String[] input;
 
 	public InvalidInputFileTest() {
-		setExpectedSystemStatus(SystemExitStatus.WITH_GREATER_THAN_0);
+		setExpectedSystemStatus(SystemExitStatus.EXACTLY.status(1));
 	}
 
 	@Test

--- a/src/final1/subtests/InvalidRecommendTerms.java
+++ b/src/final1/subtests/InvalidRecommendTerms.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 
 import test.Input;
+import test.SystemExitStatus;
 
 /**
  * Launches the program with a valid input file and then tests some illegal recommend commands.
@@ -16,6 +17,10 @@ import test.Input;
  */
 public class InvalidRecommendTerms extends RecommendationSubtest {
 	private String[] commands;
+
+	public InvalidRecommendTerms() {
+		setExpectedSystemStatus(SystemExitStatus.EXACTLY.status(1));
+	}
 
 	@Test
 	public void incomplete() {


### PR DESCRIPTION
Fix for #54. Applies the new `SystemExitStatus#EXACTLY` to all invalid tests.
