### PR TITLE
Fixes for sytem exit status

### DIFF
--- a/src/final1/subtests/InvalidRecommendTerms.java
+++ b/src/final1/subtests/InvalidRecommendTerms.java
@@ -19,7 +19,7 @@ public class InvalidRecommendTerms extends RecommendationSubtest {
 	private String[] commands;
 
 	public InvalidRecommendTerms() {
-		setExpectedSystemStatus(SystemExitStatus.EXACTLY.status(1));
+		setAllowedSystemExitStatus(SystemExitStatus.WITH_0);
 	}
 
 	@Test

--- a/src/test/KitMatchers.java
+++ b/src/test/KitMatchers.java
@@ -105,7 +105,11 @@ public class KitMatchers {
 
 			@Override
 			public void describeMismatch(final Object item, final Description description) {
-				description.appendText("was System.exit(" + item + ")");
+				if (item == null) {
+					description.appendText("was no call to System.exit at all");
+				} else {
+					description.appendText("was System.exit(" + item + ")");
+				}
 			}
 		};
 	}

--- a/src/test/TestObject.java
+++ b/src/test/TestObject.java
@@ -131,7 +131,7 @@ public class TestObject {
 	private static final String CLASS_NAME = System.getProperty("className");
 
 	private static Class<?> clazz;
-	
+
 	private static String[][] groupedProgramOutput = new String[0][];
 	private static Integer lastSystemExitStatus = null;
 	private static String[] nextCallInput;


### PR DESCRIPTION
- improved error message of `KitMatchers#suits`
  - corrected wrong system exit status in InvalidRecommendTerms
