### PR TITLE
Added ErrorOrNoOutputRun

### DIFF
--- a/src/test/runs/ErrorOrNoOutputRun.java
+++ b/src/test/runs/ErrorOrNoOutputRun.java
@@ -13,21 +13,31 @@ import test.TestObject;
  */
 public class ErrorOrNoOutputRun implements Run {
 	private String command;
+	private boolean checkSystemExitStatus;
 
 	/**
 	 * Constructs a test run for the given {@code command} that shall result in either an error message or no output at
 	 * all.
+	 * 
+	 * @param command
+	 *            The command to run
+	 * @param mustTerminate
+	 *            {@code true} if the program has to terminate after the run. Enables system exit status checking.
 	 */
-	public ErrorOrNoOutputRun(String command) {
+	public ErrorOrNoOutputRun(String command, boolean mustTerminate) {
 		this.command = command;
+		this.checkSystemExitStatus = mustTerminate;
 	}
 
 	/**
 	 * Constructs a test run without a command that shall result in either an error message or no output at all. Use
 	 * only to test errors before the first command.
+	 * 
+	 * @param mustTerminate
+	 *            {@code true} if the program has to terminate after the run. Enables system exit status checking.
 	 */
-	public ErrorOrNoOutputRun() {
-		this(null);
+	public ErrorOrNoOutputRun(boolean mustTerminate) {
+		this(null, mustTerminate);
 	}
 
 	/*
@@ -39,12 +49,17 @@ public class ErrorOrNoOutputRun implements Run {
 	public void check(String[] testedClassOutput, String errorMessage) {
 		if (testedClassOutput.length > 0) {
 			new ErrorRun(command).check(testedClassOutput, errorMessage);
-			assertThat(errorMessage + "\nYour class printed an error message. This requires System.exit(1)!",
-				TestObject.getLastMethodsSystemExitStatus(), suits(SystemExitStatus.EXACTLY.status(1), true));
+			if (checkSystemExitStatus) {
+				assertThat(errorMessage + "\nYour class printed an error message. This requires System.exit(1)!",
+					TestObject.getLastMethodsSystemExitStatus(), suits(SystemExitStatus.EXACTLY.status(1), true));
+			}
 		} else {
 			new NoOutputRun(command).check(testedClassOutput, errorMessage);
-			assertThat(errorMessage + "\nYour class did not print an error message. It may only call System.exit(0)!",
-				TestObject.getLastMethodsSystemExitStatus(), suits(SystemExitStatus.WITH_0, false));
+			if (checkSystemExitStatus) {
+				assertThat(errorMessage
+						+ "\nYour class did not print an error message. It may only call System.exit(0)!",
+					TestObject.getLastMethodsSystemExitStatus(), suits(SystemExitStatus.WITH_0, false));
+			}
 		}
 	}
 

--- a/src/test/runs/ErrorOrNoOutputRun.java
+++ b/src/test/runs/ErrorOrNoOutputRun.java
@@ -1,0 +1,61 @@
+package test.runs;
+
+/**
+ * A test run that should result in either an error message or no output at all.
+ * 
+ * @author Joshua Gleitze
+ * @version 1.0
+ */
+public class ErrorOrNoOutputRun implements Run {
+	private String command;
+
+	/**
+	 * Constructs a test run for the given {@code command} that shall result in either an error message or no output at
+	 * all.
+	 */
+	public ErrorOrNoOutputRun(String command) {
+		this.command = command;
+	}
+
+	/**
+	 * Constructs a test run without a command that shall result in either an error message or no output at all. Use
+	 * only to test errors before the first command.
+	 */
+	public ErrorOrNoOutputRun() {
+		this(null);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see test.runs.Run#check(java.lang.String[], java.lang.String)
+	 */
+	@Override
+	public void check(String[] testedClassOutput, String errorMessage) {
+		if (testedClassOutput.length > 0) {
+			new ErrorRun(command).check(testedClassOutput, errorMessage);
+		} else {
+			new NoOutputRun(command).check(testedClassOutput, errorMessage);
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see test.runs.Run#getCommand()
+	 */
+	@Override
+	public String getCommand() {
+		return command;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see test.runs.Run#getExpectedDescription()
+	 */
+	@Override
+	public String getExpectedDescription() {
+		return "Either an error message or no output at all";
+	}
+}

--- a/src/test/runs/ErrorOrNoOutputRun.java
+++ b/src/test/runs/ErrorOrNoOutputRun.java
@@ -1,5 +1,10 @@
 package test.runs;
 
+import static org.junit.Assert.assertThat;
+import static test.KitMatchers.suits;
+import test.SystemExitStatus;
+import test.TestObject;
+
 /**
  * A test run that should result in either an error message or no output at all.
  * 
@@ -34,8 +39,12 @@ public class ErrorOrNoOutputRun implements Run {
 	public void check(String[] testedClassOutput, String errorMessage) {
 		if (testedClassOutput.length > 0) {
 			new ErrorRun(command).check(testedClassOutput, errorMessage);
+			assertThat(errorMessage + "\nYour class printed an error message. This requires System.exit(1)!",
+				TestObject.getLastMethodsSystemExitStatus(), suits(SystemExitStatus.EXACTLY.status(1), true));
 		} else {
 			new NoOutputRun(command).check(testedClassOutput, errorMessage);
+			assertThat(errorMessage + "\nYour class did not print an error message. It may only call System.exit(0)!",
+				TestObject.getLastMethodsSystemExitStatus(), suits(SystemExitStatus.WITH_0, false));
 		}
 	}
 

--- a/src/test/runs/ErrorRun.java
+++ b/src/test/runs/ErrorRun.java
@@ -28,7 +28,7 @@ public class ErrorRun extends ExactRun {
 	 * first command.
 	 */
 	public ErrorRun() {
-		this("");
+		this(null);
 	}
 
 }

--- a/src/test/runs/ExactRun.java
+++ b/src/test/runs/ExactRun.java
@@ -24,6 +24,18 @@ public class ExactRun implements Run {
 	private String outputDescription;
 
 	/**
+	 * Creates a run for the given parameters, without a command. A description of the expected output will
+	 * automatically be created based on {@code expectedOutputMatchers}. Use only to test errors before the first
+	 * command.
+	 * 
+	 * @param expectedOutputMatchers
+	 *            The matchers for the expected output. One matcher per expected call to {@code Terminal.printLine}.
+	 */
+	public ExactRun(List<Matcher<String>> expectedOutputMatchers) {
+		this(null, expectedOutputMatchers);
+	}
+
+	/**
 	 * Creates a run for the given parameters. A description of the expected output will automatically be created based
 	 * on {@code expectedOutputMatchers}.
 	 * 

--- a/src/test/runs/LineRun.java
+++ b/src/test/runs/LineRun.java
@@ -24,7 +24,7 @@ public class LineRun implements Run {
 	private List<Matcher<String>> expectedResults;
 
 	/**
-	 * Creates a test run that merges all call to {@code Terminal.printLine}. The run succeeds if the merged output
+	 * Creates a test run that merges all calls to {@code Terminal.printLine}. The run succeeds if the merged output
 	 * matches {@code expectedResults} line by line.
 	 * 
 	 * @param command
@@ -38,7 +38,7 @@ public class LineRun implements Run {
 	}
 
 	/**
-	 * Creates a test run that merges all call to {@code Terminal.printLine}. The run succeeds if the merged output
+	 * Creates a test run that merges all calls to {@code Terminal.printLine}. The run succeeds if the merged output
 	 * matches {@code expectedResults} line by line.
 	 * 
 	 * @param command
@@ -49,6 +49,29 @@ public class LineRun implements Run {
 	@SafeVarargs
 	public LineRun(String command, Matcher<String>... expectedResults) {
 		this(command, Arrays.asList(expectedResults));
+	}
+
+	/**
+	 * Creates a test run without a command that merges all calls to {@code Terminal.printLine}. The run succeeds if the
+	 * merged output matches {@code expectedResults} line by line. Use only to test errors before the first command.
+	 * 
+	 * @param expectedResults
+	 *            The matchers describing the desired output
+	 */
+	public LineRun(List<Matcher<String>> expectedResults) {
+		this(null, expectedResults);
+	}
+
+	/**
+	 * Creates a test run without a command that merges all calls to {@code Terminal.printLine}. The run succeeds if the
+	 * merged output matches {@code expectedResults} line by line. Use only to test errors before the first command.
+	 * 
+	 * @param expectedResults
+	 *            The matchers describing the desired output
+	 */
+	@SafeVarargs
+	public LineRun(Matcher<String>... expectedResults) {
+		this(null, expectedResults);
 	}
 
 	/*

--- a/src/test/runs/NoOutputRun.java
+++ b/src/test/runs/NoOutputRun.java
@@ -19,4 +19,12 @@ public class NoOutputRun extends ExactRun {
 	public NoOutputRun(String command) {
 		super(command, "no output at all", new LinkedList<Matcher<String>>());
 	}
+
+	/**
+	 * Constructs a test run without a command that fails if {@code Terminal.printLine} is ever called by the tested
+	 * class. Use only to test errors before the first command.
+	 */
+	public NoOutputRun() {
+		this(null);
+	}
 }


### PR DESCRIPTION
Solves the issues we detected in #136. The new `ErrorOrNoOutputRun` is capable of asserting the output **and the system exit status**, depending if there was output or not. If there was output, it had to be an error message. System exit status checking can be enabled by passing `true` to the `mustTerminate` constructor parameter.

Note that this run performs system exit status checking. This might be unexpected for most people. Obviously, it requires to disable the system exit status checking of `InteractiveConsoleTest`.
