### PR TITLE
Fix for #145

### DIFF
--- a/src/final2/subtests/BadInputFileTest.java
+++ b/src/final2/subtests/BadInputFileTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import test.Input;
 import test.SystemExitStatus;
+import test.runs.ErrorOrNoOutputRun;
 import test.runs.ErrorRun;
 import test.runs.Run;
 
@@ -125,24 +126,26 @@ public class BadInputFileTest extends LangtonSubtest {
 	 */
 	@Test
 	public void noAntTest() {
+		setExpectedSystemStatus(null);
 		inputFile = new String[] {
 				"000",
 				"000",
 				"000"
 		};
-		sessionTest(new ErrorRun(), onlyQuit, Input.getFile(inputFile));
+		sessionTest(new ErrorOrNoOutputRun(true), new Run[0], Input.getFile(inputFile));
 		inputFile = new String[] {
 				"000",
 				"0*0",
 				"000"
 		};
-		sessionTest(new ErrorRun(), onlyQuit, Input.getFile(inputFile));
+		sessionTest(new ErrorOrNoOutputRun(true), new Run[0], Input.getFile(inputFile));
 		inputFile = new String[] {
 				"0000",
 				"0000",
 				"0000"
 		};
-		sessionTest(new ErrorRun(), onlyQuit, Input.getFile(inputFile));
+		sessionTest(new ErrorOrNoOutputRun(true), new Run[0], Input.getFile(inputFile));
+		setExpectedSystemStatus(SystemExitStatus.EXACTLY.status(1));
 	}
 
 	/**

--- a/src/test/framework/Terminal.java
+++ b/src/test/framework/Terminal.java
@@ -45,8 +45,9 @@ public class Terminal {
 
 				"public static String readLine() {",
 					"String result = \"\";",
-					"if (commandCounter >= readList.size() + 1) {",
-						"throw new RuntimeException(\"The tested class tried to get more input than there actually was!\");",
+					"if (commandCounter >= readList.size()) {",
+						"throw new RuntimeException(\"The tested class tried to get more input than there actually was!\\n\" + ",
+						"\"Most likely, it was expected to terminate!\");",
 					"}",
 					"result = readList.get(commandCounter);",
 					"commandCounter++;",


### PR DESCRIPTION
Fixes #145: If no ants are defined on the board, the game may also as well quit silently.
