### PR TITLE
bugfix: Allow all system exit statueses for noAntTest

### DIFF
--- a/src/final1/subtests/InvalidCommandLineArgumentsTest.java
+++ b/src/final1/subtests/InvalidCommandLineArgumentsTest.java
@@ -15,7 +15,7 @@ import test.SystemExitStatus;
 public class InvalidCommandLineArgumentsTest extends RecommendationSubtest {
 
 	public InvalidCommandLineArgumentsTest() {
-		setExpectedSystemStatus(SystemExitStatus.EXACTLY.status(1));
+		setExpectedSystemExitStatus(SystemExitStatus.EXACTLY.status(1));
 	}
 
 	/**

--- a/src/final1/subtests/InvalidInputFileTest.java
+++ b/src/final1/subtests/InvalidInputFileTest.java
@@ -18,7 +18,7 @@ public class InvalidInputFileTest extends RecommendationSubtest {
 	private String[] input;
 
 	public InvalidInputFileTest() {
-		setExpectedSystemStatus(SystemExitStatus.EXACTLY.status(1));
+		setExpectedSystemExitStatus(SystemExitStatus.EXACTLY.status(1));
 	}
 
 	/**

--- a/src/final2/subtests/BadInputFileTest.java
+++ b/src/final2/subtests/BadInputFileTest.java
@@ -20,7 +20,7 @@ public class BadInputFileTest extends LangtonSubtest {
 	};
 
 	public BadInputFileTest() {
-		setExpectedSystemStatus(SystemExitStatus.EXACTLY.status(1));
+		setExpectedSystemExitStatus(SystemExitStatus.EXACTLY.status(1));
 	}
 
 	/**
@@ -126,7 +126,9 @@ public class BadInputFileTest extends LangtonSubtest {
 	 */
 	@Test
 	public void noAntTest() {
-		setExpectedSystemStatus(null);
+		// Allow every system exit status, as ErrorOrNoOutputRun will handle the system exit status checking.
+		setExpectedSystemExitStatus(null);
+		setAllowedSystemExitStatus(SystemExitStatus.ALL);
 		inputFile = new String[] {
 				"000",
 				"000",
@@ -145,7 +147,7 @@ public class BadInputFileTest extends LangtonSubtest {
 				"0000"
 		};
 		sessionTest(new ErrorOrNoOutputRun(true), new Run[0], Input.getFile(inputFile));
-		setExpectedSystemStatus(SystemExitStatus.EXACTLY.status(1));
+		setExpectedSystemExitStatus(SystemExitStatus.EXACTLY.status(1));
 	}
 
 	/**

--- a/src/final2/subtests/InvalidCommandLineArgumentsTest.java
+++ b/src/final2/subtests/InvalidCommandLineArgumentsTest.java
@@ -17,7 +17,7 @@ import test.SystemExitStatus;
 public class InvalidCommandLineArgumentsTest extends LangtonSubtest {
 
 	public InvalidCommandLineArgumentsTest() {
-		setExpectedSystemStatus(SystemExitStatus.EXACTLY.status(1));
+		setExpectedSystemExitStatus(SystemExitStatus.EXACTLY.status(1));
 	}
 
 	/*

--- a/src/test/InteractiveConsoleTest.java
+++ b/src/test/InteractiveConsoleTest.java
@@ -42,7 +42,7 @@ import test.runs.Run;
  * <li>It differentiates between an <i>expected</i> and an <i>allowed</i> system exit status.
  * </ul>
  * To use the new way, call {@link #setAllowedSystemExitStatus(SystemExitStatus)} or
- * {@link #setExpectedSystemStatus(SystemExitStatus)} before running one of the test methods. Typically, a test class
+ * {@link #setExpectedSystemExitStatus(SystemExitStatus)} before running one of the test methods. Typically, a test class
  * does this once in its constructor.
  * 
  * @author Roman Langrehr
@@ -157,7 +157,7 @@ public abstract class InteractiveConsoleTest {
 	 * Override this method if you wish to have another default system exit status.
 	 * <p>
 	 * <i>Deprecated. Please use {@link #setAllowedSystemExitStatus(SystemExitStatus)} and
-	 * {@link #setExpectedSystemStatus(SystemExitStatus)}.
+	 * {@link #setExpectedSystemExitStatus(SystemExitStatus)}.
 	 */
 	@Deprecated
 	@Before
@@ -648,7 +648,7 @@ public abstract class InteractiveConsoleTest {
 	 * the deprecated way through {@link #defaultSystemExitStatus()}. The setting stays until the next call to this
 	 * method.
 	 * <p>
-	 * NOTE: This setting only takes effect if {@link #setExpectedSystemStatus(SystemExitStatus)} was called with
+	 * NOTE: This setting only takes effect if {@link #setExpectedSystemExitStatus(SystemExitStatus)} was called with
 	 * {@code null}!
 	 * 
 	 * @param status
@@ -671,7 +671,7 @@ public abstract class InteractiveConsoleTest {
 	 *            The {@code x} the tested class has to call {@code System.exit} with. Set to {@code null} if the tested
 	 *            class does not necessary have to call {@code System.exit}.
 	 */
-	protected final void setExpectedSystemStatus(SystemExitStatus status) {
+	protected final void setExpectedSystemExitStatus(SystemExitStatus status) {
 		expectedExitStatus = status;
 	}
 


### PR DESCRIPTION
- Allow all system exit status for noAntTest, as `ErrorOrNoOutputRun` will handle the status checking (`1` as permitted)
- Rename `InteractiveConsoleTest#setExpectedSystemStatus` to `IneractiveConsoleTest#setExcpectedSystemExitStatus`
