### PR TITLE
Better sorting of ant-subtests

### DIFF
--- a/src/final2/LangtonTest.java
+++ b/src/final2/LangtonTest.java
@@ -26,19 +26,19 @@ import final2.subtests.ValidCommandLineArgumentsTest;
  */
 @RunWith(KITSuite.class)
 @SuiteClasses({
+		QuitTest.class,
 		ValidCommandLineArgumentsTest.class,
 		InvalidCommandLineArgumentsTest.class,
 		ValidInputFileTest.class,
-		PraktomatPublicTest.class,
-		MoveTest.class,
-		PrintTest.class,
 		InvalidInputFileTest.class,
+		InvalidCommandTest.class,
+		PrintTest.class,
+		MoveTest.class,
 		PositionTest.class,
 		AntTest.class,
 		CreateTest.class,
 		EscapeTest.class,
-		QuitTest.class,
-		InvalidCommandTest.class
+		PraktomatPublicTest.class,
 })
 public class LangtonTest {
 }

--- a/src/final2/LangtonTest.java
+++ b/src/final2/LangtonTest.java
@@ -28,16 +28,16 @@ import final2.subtests.ValidCommandLineArgumentsTest;
 @SuiteClasses({
 		QuitTest.class,
 		ValidCommandLineArgumentsTest.class,
-		InvalidCommandLineArgumentsTest.class,
 		ValidInputFileTest.class,
-		InvalidInputFileTest.class,
-		InvalidCommandTest.class,
 		PrintTest.class,
 		MoveTest.class,
 		PositionTest.class,
 		AntTest.class,
 		CreateTest.class,
 		EscapeTest.class,
+		InvalidCommandLineArgumentsTest.class,
+		InvalidInputFileTest.class,
+		InvalidCommandTest.class,
 		PraktomatPublicTest.class,
 })
 public class LangtonTest {


### PR DESCRIPTION
Unlike test methods in a test class, the test classes defined for a suite are run strictly in the order they are declared.

Therefore I'd like to establish this new sorting, which makes much more sense IMHO. It runs tests that test preconditions of other tests first.
