### PR TITLE
Integer format tests: remove "+" tests; use smaller invalid numbers

### DIFF
--- a/src/final2/subtests/InvalidCommandLineArgumentsTest.java
+++ b/src/final2/subtests/InvalidCommandLineArgumentsTest.java
@@ -105,12 +105,6 @@ public class InvalidCommandLineArgumentsTest extends LangtonSubtest {
 
 		errorTest("quit", Input.getFile(TASK_SHEET_INPUT_FILE_1), "Rule=90-315-45-90-270");
 		errorTest("quit", Input.getFile(TASK_SHEET_INPUT_FILE_1), "ruLe=90-315-45-90-270");
-
-		errorTest("quit", Input.getFile(TASK_SHEET_INPUT_FILE_1), "rule=+90-315-45-90-270");
-		errorTest("quit", Input.getFile(TASK_SHEET_INPUT_FILE_1), "rule=90-+315-45-90-270");
-		errorTest("quit", Input.getFile(TASK_SHEET_INPUT_FILE_1), "rule=90-315-+45-90-270");
-		errorTest("quit", Input.getFile(TASK_SHEET_INPUT_FILE_1), "rule=90-315-45-+90-270");
-		errorTest("quit", Input.getFile(TASK_SHEET_INPUT_FILE_1), "rule=90-315-45-90-+270");
 	}
 
 	/**
@@ -126,8 +120,6 @@ public class InvalidCommandLineArgumentsTest extends LangtonSubtest {
 
 		errorTest("quit", Input.getFile(TASK_SHEET_INPUT_FILE_1), "speedUp=12");
 		errorTest("quit", Input.getFile(TASK_SHEET_INPUT_FILE_1), "Speedup=12");
-
-		errorTest("quit", Input.getFile(TASK_SHEET_INPUT_FILE_1), "speedup=+12");
 	}
 
 	/**

--- a/src/final2/subtests/InvalidCommandTest.java
+++ b/src/final2/subtests/InvalidCommandTest.java
@@ -34,9 +34,9 @@ public class InvalidCommandTest extends LangtonSubtest {
 
 	private static final String[] INVALID_NUMBERS = new String[] {
 			"a",
-			"12t",
-			"three",
-			"12.5",
+			"1t",
+			"two",
+			"1.5",
 			"$",
 			"9999999999999999999999999999999999999999999999999999999999999999"
 	};

--- a/src/final2/subtests/InvalidCommandTest.java
+++ b/src/final2/subtests/InvalidCommandTest.java
@@ -12,7 +12,7 @@ import test.runs.Run;
  * 
  * @author Roman Langrehr
  * @since 26.03.2015
- *
+ * 
  */
 public class InvalidCommandTest extends LangtonSubtest {
 
@@ -38,9 +38,7 @@ public class InvalidCommandTest extends LangtonSubtest {
 			"three",
 			"12.5",
 			"$",
-			"9999999999999999999999999999999999999999999999999999999999999999",
-			"+0",
-			"+1"
+			"9999999999999999999999999999999999999999999999999999999999999999"
 	};
 
 	private static final String[] NO_ARGUMENT_COMMANDS = new String[] {


### PR DESCRIPTION
final2: Remove tests with integers prefixed with +
As discussed in #172 

InvalidCommandTest: use "smaller" invalid numbers
So the chance of them being interpreted as correct is higher
